### PR TITLE
fix:  bad format of rpc subscribe response 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -248,7 +248,7 @@ require (
 replace (
 	github.com/cosmos/ibc-go/v3 => github.com/dymensionxyz/ibc-go/v3 v3.0.0-rc2.0.20230105134315-1870174ab6da
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.2-alpha.regen.4
-	github.com/gorilla/rpc => github.com/dymensionxyz/rpc v1.2.1
+	github.com/gorilla/rpc => github.com/dymensionxyz/rpc v1.3.1
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
 
 )

--- a/go.sum
+++ b/go.sum
@@ -278,8 +278,8 @@ github.com/dymensionxyz/dymension v0.1.0-alpha.0.20230110174626-23b70dccd1e5 h1:
 github.com/dymensionxyz/dymension v0.1.0-alpha.0.20230110174626-23b70dccd1e5/go.mod h1:C5nQlAlDqVtNigjQVNLSL4SuC3gUVoRhqAsfYZZcDgs=
 github.com/dymensionxyz/ibc-go/v3 v3.0.0-rc2.0.20230105134315-1870174ab6da h1:driSbrBc4deT0iRjDKjA4royFDsUsDcE0IgFkFxhopo=
 github.com/dymensionxyz/ibc-go/v3 v3.0.0-rc2.0.20230105134315-1870174ab6da/go.mod h1:VwB/vWu4ysT5DN2aF78d17LYmx3omSAdq6gpKvM7XRA=
-github.com/dymensionxyz/rpc v1.2.1 h1:UeKupQewBeiLO3qqMZQ6jtqUNmb9AaCXm+G6ibMSxIg=
-github.com/dymensionxyz/rpc v1.2.1/go.mod h1:f+WpX8ysy8wt95iGc6auYlHcnHj2bUkhiRVkkKNys8c=
+github.com/dymensionxyz/rpc v1.3.1 h1:7EXWIobaBes5zldRvTIg7TmNsEKjicrWA/OjCc0NaGs=
+github.com/dymensionxyz/rpc v1.3.1/go.mod h1:f+WpX8ysy8wt95iGc6auYlHcnHj2bUkhiRVkkKNys8c=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=

--- a/rpc/json/handler.go
+++ b/rpc/json/handler.go
@@ -86,6 +86,12 @@ func (h *handler) serveJSONRPCforWS(w http.ResponseWriter, r *http.Request, wsCo
 	}
 	if methodSpec.ws {
 		callArgs = append(callArgs, reflect.ValueOf(wsConn))
+		rpcID, err := codecReq.ID()
+		if err != nil {
+			codecReq.WriteError(w, http.StatusBadRequest, err)
+			return
+		}
+		callArgs = append(callArgs, reflect.ValueOf(rpcID))
 	}
 	rets := methodSpec.m.Call(callArgs)
 


### PR DESCRIPTION
The subscribe response returned to register clients using ws had 2 issues:
1. It wasn't json-rpc 2.0 compatible
2. The response body didn't match what clients (such as keplr) were expecting.