### PR TITLE
fix: distinguish between different errors of state loading

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -197,18 +197,22 @@ func (s *DefaultStore) UpdateState(state types.State, batch Batch) (Batch, error
 func (s *DefaultStore) LoadState() (types.State, error) {
 	blob, err := s.db.Get(getStateKey())
 	if err != nil {
-		return types.State{}, fmt.Errorf("failed to retrieve state: %w", err)
+		return types.State{}, types.ErrNoStateFound
 	}
 	var pbState pb.State
 	err = pbState.Unmarshal(blob)
 	if err != nil {
-		return types.State{}, fmt.Errorf("failed to unmarshal state from JSON: %w", err)
+		return types.State{}, fmt.Errorf("failed to unmarshal state from store: %w", err)
 	}
 
 	var state types.State
 	err = state.FromProto(&pbState)
+	if err != nil {
+		return types.State{}, fmt.Errorf("failed to unmarshal state from proto: %w", err)
+	}
+
 	atomic.StoreUint64(&s.height, state.LastStoreHeight)
-	return state, err
+	return state, nil
 }
 
 // SaveValidators stores validator set for given block height in store.

--- a/types/errors.go
+++ b/types/errors.go
@@ -5,4 +5,5 @@ import "errors"
 var (
 	// ErrInvalidSignature is returned when a signature is invalid.
 	ErrInvalidSignature = errors.New("invalid signature")
+	ErrNoStateFound     = errors.New("no state found")
 )


### PR DESCRIPTION
This PR adds validation that the state loaded correctly on init.

The initial state is created from the genesis file.
Afterward, the state expected to be loaded from persistent storage


# PR Standards

## Opening a pull request should be able to meet the following requirements

---

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
