### PR TITLE
feat: mock SL doesn't use keyring path from config. 

### DIFF
--- a/config/defaults.go
+++ b/config/defaults.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"path/filepath"
 	"time"
 
 	"github.com/dymensionxyz/dymint/settlement"
@@ -12,7 +13,7 @@ const (
 	// Version is a default dymint version for P2P client.
 	Version = "0.2.2"
 
-	DefaultHomeDir = ".dymint"
+	DefaultHomeDir = "sequencer_keys"
 	DefaultChainID = "dymint-testnet"
 )
 
@@ -28,8 +29,8 @@ func DefaultConfig(home, chainId string) *NodeConfig {
 		Aggregator: true,
 		BlockManagerConfig: BlockManagerConfig{
 			BlockTime:           200 * time.Millisecond,
-			EmptyBlocksMaxTime:  60 * time.Second,
-			BatchSubmitMaxTime:  600 * time.Second,
+			EmptyBlocksMaxTime:  3 * time.Second,
+			BatchSubmitMaxTime:  20 * time.Second,
 			NamespaceID:         "000000000000ffff",
 			BlockBatchSize:      500,
 			BlockBatchSizeBytes: 1500000},
@@ -38,8 +39,9 @@ func DefaultConfig(home, chainId string) *NodeConfig {
 	}
 
 	if home == "" {
-		home = DefaultHomeDir
+		home = "/tmp"
 	}
+	keyringDir := filepath.Join(home, DefaultHomeDir)
 	if chainId == "" {
 		chainId = DefaultChainID
 	}
@@ -48,7 +50,7 @@ func DefaultConfig(home, chainId string) *NodeConfig {
 		KeyringBackend: "test",
 		NodeAddress:    "http://127.0.0.1:36657",
 		RollappID:      chainId,
-		KeyringHomeDir: home,
+		KeyringHomeDir: keyringDir,
 		DymAccountName: "sequencer",
 		GasPrices:      "0.025udym",
 	}

--- a/node/integration_test.go
+++ b/node/integration_test.go
@@ -3,6 +3,7 @@ package node
 import (
 	"context"
 	"crypto/rand"
+	"encoding/hex"
 	mrand "math/rand"
 	"testing"
 	"time"
@@ -38,7 +39,10 @@ func TestAggregatorMode(t *testing.T) {
 	app.On("Info", mock.Anything).Return(abci.ResponseInfo{LastBlockHeight: 0, LastBlockAppHash: []byte{0}})
 
 	key, _, _ := crypto.GenerateEd25519Key(rand.Reader)
-	signingKey, _, _ := crypto.GenerateEd25519Key(rand.Reader)
+	signingKey, pubkey, _ := crypto.GenerateEd25519Key(rand.Reader)
+	pubkeyBytes, _ := pubkey.Raw()
+	proposerKey := hex.EncodeToString(pubkeyBytes)
+
 	anotherKey, _, _ := crypto.GenerateEd25519Key(rand.Reader)
 
 	blockManagerConfig := config.BlockManagerConfig{
@@ -57,7 +61,7 @@ func TestAggregatorMode(t *testing.T) {
 		DALayer:            "mock",
 		DAConfig:           "",
 		SettlementLayer:    "mock",
-		SettlementConfig:   settlement.Config{},
+		SettlementConfig:   settlement.Config{ProposerPubKey: proposerKey},
 	}
 	node, err := NewNode(context.Background(), nodeConfig, key, signingKey, proxy.NewLocalClientCreator(app), &types.GenesisDoc{ChainID: "test"}, log.TestingLogger())
 	require.NoError(err)

--- a/node/node.go
+++ b/node/node.go
@@ -3,7 +3,6 @@ package node
 import (
 	"context"
 	"encoding/base64"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"sync"
@@ -159,11 +158,7 @@ func NewNode(ctx context.Context, conf config.NodeConfig, p2pKey crypto.PrivKey,
 		return nil, fmt.Errorf("couldn't get settlement client named '%s'", conf.SettlementLayer)
 	}
 	if conf.SettlementLayer == "mock" {
-		pubKeybytes, err := signingKey.GetPublic().Raw()
-		if err != nil {
-			return nil, err
-		}
-		conf.SettlementConfig.ProposerPubKey = hex.EncodeToString(pubKeybytes)
+		conf.SettlementConfig.KeyringHomeDir = conf.RootDir
 	}
 	err = settlementlc.Init(conf.SettlementConfig, pubsubServer, logger.With("module", "settlement_client"))
 	if err != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -3,6 +3,7 @@ package node
 import (
 	"context"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"sync"
@@ -156,6 +157,13 @@ func NewNode(ctx context.Context, conf config.NodeConfig, p2pKey crypto.PrivKey,
 	settlementlc := slregistry.GetClient(slregistry.Client(conf.SettlementLayer))
 	if settlementlc == nil {
 		return nil, fmt.Errorf("couldn't get settlement client named '%s'", conf.SettlementLayer)
+	}
+	if conf.SettlementLayer == "mock" {
+		pubKeybytes, err := signingKey.GetPublic().Raw()
+		if err != nil {
+			return nil, err
+		}
+		conf.SettlementConfig.ProposerPubKey = hex.EncodeToString(pubKeybytes)
 	}
 	err = settlementlc.Init(conf.SettlementConfig, pubsubServer, logger.With("module", "settlement_client"))
 	if err != nil {

--- a/rpc/client/client_test.go
+++ b/rpc/client/client_test.go
@@ -795,7 +795,9 @@ func getRPC(t *testing.T) (*mocks.Application, *Client) {
 	app := &mocks.Application{}
 	app.On("InitChain", mock.Anything).Return(abci.ResponseInitChain{})
 	key, _, _ := crypto.GenerateEd25519Key(crand.Reader)
-	signingKey, _, err := crypto.GenerateEd25519Key(crand.Reader)
+	signingKey, pubkey, err := crypto.GenerateEd25519Key(crand.Reader)
+	pubkeyBytes, _ := pubkey.Raw()
+	proposerKey := hex.EncodeToString(pubkeyBytes)
 	require.NoError(err)
 
 	config := config.NodeConfig{
@@ -808,7 +810,7 @@ func getRPC(t *testing.T) (*mocks.Application, *Client) {
 		DALayer:            "mock",
 		DAConfig:           "",
 		SettlementLayer:    "mock",
-		SettlementConfig:   settlement.Config{},
+		SettlementConfig:   settlement.Config{ProposerPubKey: proposerKey},
 	}
 	node, err := node.NewNode(context.Background(), config, key, signingKey, proxy.NewLocalClientCreator(app), &tmtypes.GenesisDoc{ChainID: "test"}, log.TestingLogger())
 	require.NoError(err)

--- a/settlement/mock/mock.go
+++ b/settlement/mock/mock.go
@@ -7,10 +7,12 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"path/filepath"
 	"sync/atomic"
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/crypto"
+	tmp2p "github.com/tendermint/tendermint/p2p"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
@@ -23,6 +25,8 @@ import (
 
 	"github.com/tendermint/tendermint/libs/pubsub"
 )
+
+const kvStoreDBName = "settlement"
 
 var settlementKVPrefix = []byte{0}
 var slStateIndexKey = []byte("slStateIndex")
@@ -104,22 +108,32 @@ func newHubClient(config settlement.Config, pubsub *pubsub.Server, logger log.Lo
 }
 
 func initConfig(conf settlement.Config) (slstore store.KVStore, proposer string, err error) {
-	slstore = store.NewDefaultInMemoryKVStore()
+	if conf.KeyringHomeDir == "" {
+		//init store
+		slstore = store.NewDefaultInMemoryKVStore()
+		//init proposer pub key
+		if conf.ProposerPubKey != "" {
+			proposer = conf.ProposerPubKey
+		} else {
+			_, proposerPubKey, err := crypto.GenerateEd25519Key(rand.Reader)
+			if err != nil {
+				return nil, "", err
+			}
+			pubKeybytes, err := proposerPubKey.Raw()
+			if err != nil {
+				return nil, "", err
+			}
 
-	//init proposer pub key
-	if conf.ProposerPubKey != "" {
-		proposer = conf.ProposerPubKey
+			proposer = hex.EncodeToString(pubKeybytes)
+		}
 	} else {
-		_, proposerPubKey, err := crypto.GenerateEd25519Key(rand.Reader)
+		slstore = store.NewDefaultKVStore(conf.KeyringHomeDir, "data", kvStoreDBName)
+		proposerKeyPath := filepath.Join(conf.KeyringHomeDir, "config/priv_validator_key.json")
+		key, err := tmp2p.LoadOrGenNodeKey(proposerKeyPath)
 		if err != nil {
 			return nil, "", err
 		}
-		pubKeybytes, err := proposerPubKey.Raw()
-		if err != nil {
-			return nil, "", err
-		}
-
-		proposer = hex.EncodeToString(pubKeybytes)
+		proposer = hex.EncodeToString(key.PubKey().Bytes())
 	}
 
 	return


### PR DESCRIPTION
mock SL doesn't use keyring path from config
this allows us to set whenever keyring_dir for the sequencer as default

set defaults to be more clear and useful for local run

The default path for sequencer keys will be `rootDir/sequecner_keys`

# PR Standards

## Opening a pull request should be able to meet the following requirements

---

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
