### PR TITLE
fix: fixed race condition in some DA tests

### DIFF
--- a/da/celestia/celestia_test.go
+++ b/da/celestia/celestia_test.go
@@ -10,13 +10,14 @@ import (
 	"github.com/celestiaorg/go-cnc"
 	"github.com/dymensionxyz/dymint/da"
 	"github.com/dymensionxyz/dymint/da/celestia"
-	"github.com/dymensionxyz/dymint/log/test"
 	mocks "github.com/dymensionxyz/dymint/mocks/da/celestia"
 	"github.com/dymensionxyz/dymint/testutil"
 	"github.com/dymensionxyz/dymint/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/log"
+
 	"github.com/tendermint/tendermint/libs/bytes"
 	"github.com/tendermint/tendermint/libs/pubsub"
 	rpcmock "github.com/tendermint/tendermint/rpc/client/mocks"
@@ -114,7 +115,7 @@ func TestSubmitBatch(t *testing.T) {
 		assert.NoError(err)
 		// Start the DALC
 		dalc := celestia.DataAvailabilityLayerClient{}
-		err = dalc.Init(configBytes, pubsubServer, nil, test.NewLogger(t), options...)
+		err = dalc.Init(configBytes, pubsubServer, nil, log.TestingLogger(), options...)
 		require.NoError(err)
 		err = dalc.Start()
 		require.NoError(err)

--- a/da/celestia/mock/server.go
+++ b/da/celestia/mock/server.go
@@ -48,9 +48,9 @@ func (s *Server) Start(listener net.Listener) error {
 	if err != nil {
 		return err
 	}
+	s.server = new(http.Server)
+	s.server.Handler = s.getHandler()
 	go func() {
-		s.server = new(http.Server)
-		s.server.Handler = s.getHandler()
 		err := s.server.Serve(listener)
 		s.logger.Debug("http server exited with", "error", err)
 	}()

--- a/da/da_test.go
+++ b/da/da_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/tendermint/tendermint/libs/pubsub"
 	"google.golang.org/grpc"
 
+	"github.com/tendermint/tendermint/libs/log"
+
 	"github.com/dymensionxyz/dymint/da"
 	"github.com/dymensionxyz/dymint/da/celestia"
 	cmock "github.com/dymensionxyz/dymint/da/celestia/mock"
@@ -21,7 +23,6 @@ import (
 	"github.com/dymensionxyz/dymint/da/grpc/mockserv"
 	"github.com/dymensionxyz/dymint/da/mock"
 	"github.com/dymensionxyz/dymint/da/registry"
-	"github.com/dymensionxyz/dymint/log/test"
 	"github.com/dymensionxyz/dymint/store"
 	"github.com/dymensionxyz/dymint/types"
 )
@@ -35,7 +36,7 @@ func TestLifecycle(t *testing.T) {
 	for _, dalc := range registry.RegisteredClients() {
 		//TODO(omritoptix): Possibly add support for avail here.
 		if dalc == "avail" {
-			t.Skip("TODO")
+			continue
 		}
 		t.Run(dalc, func(t *testing.T) {
 			doTestLifecycle(t, dalc)
@@ -57,7 +58,7 @@ func doTestLifecycle(t *testing.T, daType string) {
 		require.NoError(err)
 	}
 
-	err = dalc.Init(dacfg, pubsubServer, nil, test.NewLogger(t))
+	err = dalc.Init(dacfg, pubsubServer, nil, log.TestingLogger())
 	require.NoError(err)
 
 	err = dalc.Start()
@@ -77,7 +78,7 @@ func TestDALC(t *testing.T) {
 	for _, dalc := range registry.RegisteredClients() {
 		//TODO(omritoptix): Possibly add support for avail here.
 		if dalc == "avail" {
-			t.Skip("TODO")
+			continue
 		}
 		t.Run(dalc, func(t *testing.T) {
 			doTestDALC(t, registry.GetClient(dalc))
@@ -106,7 +107,7 @@ func doTestDALC(t *testing.T, dalc da.DataAvailabilityLayerClient) {
 	}
 	pubsubServer := pubsub.NewServer()
 	pubsubServer.Start()
-	err := dalc.Init(conf, pubsubServer, store.NewDefaultInMemoryKVStore(), test.NewLogger(t))
+	err := dalc.Init(conf, pubsubServer, store.NewDefaultInMemoryKVStore(), log.TestingLogger())
 	require.NoError(err)
 
 	err = dalc.Start()
@@ -164,11 +165,11 @@ func TestRetrieve(t *testing.T) {
 	defer httpServer.Stop()
 
 	for _, client := range registry.RegisteredClients() {
+		//TODO(omritoptix): Possibly add support for avail here.
+		if client == "avail" {
+			continue
+		}
 		t.Run(client, func(t *testing.T) {
-			//TODO(omritoptix): Possibly add support for avail here.
-			if client == "avail" {
-				t.Skip("TODO")
-			}
 			dalc := registry.GetClient(client)
 			_, ok := dalc.(da.BatchRetriever)
 			if ok {
@@ -194,7 +195,7 @@ func startMockGRPCServ(t *testing.T) *grpc.Server {
 
 func startMockCelestiaNodeServer(t *testing.T) *cmock.Server {
 	t.Helper()
-	httpSrv := cmock.NewServer(mockDaBlockTime, test.NewLogger(t))
+	httpSrv := cmock.NewServer(mockDaBlockTime, log.TestingLogger())
 	l, err := net.Listen("tcp4", ":26658")
 	if err != nil {
 		t.Fatal("failed to create listener for mock celestia-node RPC server", "error", err)
@@ -227,7 +228,7 @@ func doTestRetrieve(t *testing.T, dalc da.DataAvailabilityLayerClient) {
 	}
 	pubsubServer := pubsub.NewServer()
 	pubsubServer.Start()
-	err := dalc.Init(conf, pubsubServer, store.NewDefaultInMemoryKVStore(), test.NewLogger(t))
+	err := dalc.Init(conf, pubsubServer, store.NewDefaultInMemoryKVStore(), log.TestingLogger())
 	require.NoError(err)
 
 	err = dalc.Start()

--- a/p2p/client_test.go
+++ b/p2p/client_test.go
@@ -7,12 +7,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ipfs/go-log"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/dymensionxyz/dymint/config"
 	"github.com/dymensionxyz/dymint/log/test"
@@ -20,7 +21,7 @@ import (
 
 func TestClientStartup(t *testing.T) {
 	privKey, _, _ := crypto.GenerateEd25519Key(rand.Reader)
-	client, err := NewClient(config.P2PConfig{}, privKey, "TestChain", test.NewLogger(t))
+	client, err := NewClient(config.P2PConfig{}, privKey, "TestChain", log.TestingLogger())
 	assert := assert.New(t)
 	assert.NoError(err)
 	assert.NotNil(client)
@@ -33,11 +34,8 @@ func TestClientStartup(t *testing.T) {
 }
 
 func TestBootstrapping(t *testing.T) {
-	_ = log.SetLogLevel("dht", "INFO")
-	//log.SetDebugLogging()
-
 	assert := assert.New(t)
-	logger := test.NewLogger(t)
+	logger := log.TestingLogger()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -57,7 +55,7 @@ func TestBootstrapping(t *testing.T) {
 
 func TestDiscovery(t *testing.T) {
 	assert := assert.New(t)
-	logger := test.NewLogger(t)
+	logger := log.TestingLogger()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -77,7 +75,7 @@ func TestDiscovery(t *testing.T) {
 
 func TestGossiping(t *testing.T) {
 	assert := assert.New(t)
-	logger := test.NewLogger(t)
+	logger := log.TestingLogger()
 
 	ctx := context.Background()
 

--- a/settlement/dymension/dymension_test.go
+++ b/settlement/dymension/dymension_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/tendermint/tendermint/libs/log"
+
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
@@ -25,7 +27,6 @@ import (
 	rollapptypes "github.com/dymensionxyz/dymension/x/rollapp/types"
 	sequencertypes "github.com/dymensionxyz/dymension/x/sequencer/types"
 	"github.com/dymensionxyz/dymint/da"
-	"github.com/dymensionxyz/dymint/log/test"
 	mocks "github.com/dymensionxyz/dymint/mocks"
 	settlementmocks "github.com/dymensionxyz/dymint/mocks/settlement"
 	"github.com/dymensionxyz/dymint/settlement"
@@ -53,7 +54,7 @@ func TestGetSequencers(t *testing.T) {
 	pubsubServer := pubsub.NewServer()
 	pubsubServer.Start()
 
-	hubClient, err := newDymensionHubClient(settlement.Config{}, pubsubServer, test.NewLogger(t), options...)
+	hubClient, err := newDymensionHubClient(settlement.Config{}, pubsubServer, log.TestingLogger(), options...)
 	require.NoError(err)
 
 	sequencers, err := hubClient.GetSequencers("mock-rollapp")
@@ -196,7 +197,7 @@ func TestPostBatch(t *testing.T) {
 					rollappQueryClientMock.On("LatestStateIndex", mock.Anything, mock.Anything).Return(nil, nil)
 				}
 			}
-			hubClient, err := newDymensionHubClient(settlement.Config{}, pubsubServer, test.NewLogger(t), options...)
+			hubClient, err := newDymensionHubClient(settlement.Config{}, pubsubServer, log.TestingLogger(), options...)
 			require.NoError(err)
 			hubClient.Start()
 			// Handle the various events that are emitted and timeout if we don't get them

--- a/settlement/settlement_test.go
+++ b/settlement/settlement_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/tendermint/tendermint/libs/log"
+
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,7 +14,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	"github.com/dymensionxyz/dymint/da"
-	"github.com/dymensionxyz/dymint/log/test"
 	mocks "github.com/dymensionxyz/dymint/mocks/settlement"
 	"github.com/dymensionxyz/dymint/settlement"
 	"github.com/dymensionxyz/dymint/settlement/registry"
@@ -31,7 +32,7 @@ func TestLifecycle(t *testing.T) {
 
 	pubsubServer := pubsub.NewServer()
 	pubsubServer.Start()
-	err := client.Init(settlement.Config{}, pubsubServer, test.NewLogger(t))
+	err := client.Init(settlement.Config{}, pubsubServer, log.TestingLogger())
 	require.NoError(err)
 
 	err = client.Start()
@@ -144,7 +145,7 @@ func TestGetSequencersEmptyList(t *testing.T) {
 
 	pubsubServer := pubsub.NewServer()
 	pubsubServer.Start()
-	err := settlementClient.Init(settlement.Config{}, pubsubServer, test.NewLogger(t), options...)
+	err := settlementClient.Init(settlement.Config{}, pubsubServer, log.TestingLogger(), options...)
 	assert.Error(t, err, "empty sequencer list should return an error")
 
 }
@@ -194,7 +195,7 @@ func initClient(t *testing.T, settlementlc settlement.LayerI, options ...settlem
 
 	pubsubServer := pubsub.NewServer()
 	pubsubServer.Start()
-	err := settlementlc.Init(settlement.Config{}, pubsubServer, test.NewLogger(t), options...)
+	err := settlementlc.Init(settlement.Config{}, pubsubServer, log.TestingLogger(), options...)
 	require.NoError(err)
 
 	err = settlementlc.Start()


### PR DESCRIPTION
1. fixed bug in `da/celestia/mock/server.go`
2. removed the usage of `test.NewLogger(t)` as it's causes some racing errors (in case go routines exists and writes to log after the test is finished)
3. changed `t.Skip("TODO")` to continue in da tests


# PR Standards

## Opening a pull request should be able to meet the following requirements

---

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
