### PR TITLE
fix: adding only the proposer in manager initchain

### DIFF
--- a/block/manager.go
+++ b/block/manager.go
@@ -131,14 +131,13 @@ func NewManager(
 	validators := []*tmtypes.Validator{}
 
 	if s.LastBlockHeight+1 == genesis.InitialHeight {
-		sequencersList := settlementClient.GetSequencersList()
-		for _, sequencer := range sequencersList {
-			tmPubKey, err := cryptocodec.ToTmPubKeyInterface(sequencer.PublicKey)
-			if err != nil {
-				return nil, err
-			}
-			validators = append(validators, tmtypes.NewValidator(tmPubKey, 1))
+
+		sequencer := settlementClient.GetProposer()
+		tmPubKey, err := cryptocodec.ToTmPubKeyInterface(sequencer.PublicKey)
+		if err != nil {
+			return nil, err
 		}
+		validators = append(validators, tmtypes.NewValidator(tmPubKey, 1))
 
 		res, err := exec.InitChain(genesis, validators)
 		if err != nil {

--- a/block/manager_test.go
+++ b/block/manager_test.go
@@ -455,6 +455,7 @@ func TestCreateNextDABatchWithBytesLimit(t *testing.T) {
 	}
 }
 
+// TestManagerSequencer checks that the manager inits the chain with only the proposer as validator
 func TestManagerSequencer(t *testing.T) {
 
 	pubsubServer := pubsub.NewServer()

--- a/block/manager_test.go
+++ b/block/manager_test.go
@@ -454,3 +454,23 @@ func TestCreateNextDABatchWithBytesLimit(t *testing.T) {
 		})
 	}
 }
+
+func TestManagerSequencer(t *testing.T) {
+
+	pubsubServer := pubsub.NewServer()
+	pubsubServer.Start()
+
+	settlementlc := slregistry.GetClient(slregistry.Client("mock"))
+	err := settlementlc.Init(settlement.Config{}, pubsubServer, log.TestingLogger())
+	require.NoError(t, err)
+
+	manager, err := getManager(getManagerConfig(), settlementlc, nil, 1, 1, 0, nil, nil)
+	require.NoError(t, err)
+
+	proposer := settlementlc.GetProposer()
+
+	validatorPubKey := manager.lastState.NextValidators.Validators[0].PubKey
+	require.Equal(t, len(manager.lastState.NextValidators.Validators), 1)
+	require.Equal(t, validatorPubKey.Address(), proposer.PublicKey.Address())
+
+}

--- a/settlement/mock/mock.go
+++ b/settlement/mock/mock.go
@@ -184,19 +184,32 @@ func (c *HubClient) GetBatchAtIndex(rollappID string, index uint64) (*settlement
 	return batchResult, nil
 }
 
-// GetSequencers returns a list of sequencers. Currently only returns a single sequencer
+// GetSequencers returns a list of sequencers. Currently returns between 1 and 5 sequencer
 func (c *HubClient) GetSequencers(rollappID string) ([]*types.Sequencer, error) {
-	pubKeyBytes, err := hex.DecodeString(c.ProposerPubKey)
-	if err != nil {
-		return nil, err
-	}
-	var pubKey cryptotypes.PubKey = &ed25519.PubKey{Key: pubKeyBytes}
-	return []*types.Sequencer{
-		{
+
+	numSequencers := 5
+	var sequencers []*types.Sequencer
+
+	for i := 0; i < numSequencers; i++ {
+		pubKeyBytes, err := hex.DecodeString(c.ProposerPubKey)
+		if err != nil {
+			return nil, err
+		}
+		var pubKey cryptotypes.PubKey = &ed25519.PubKey{Key: pubKeyBytes}
+		var status types.SequencerStatus
+		if i == 0 {
+			status = types.Proposer
+		} else {
+			status = types.Inactive
+		}
+		sequencer := &types.Sequencer{
 			PublicKey: pubKey,
-			Status:    types.Proposer,
-		},
-	}, nil
+			Status:    status,
+		}
+		sequencers = append(sequencers, sequencer)
+
+	}
+	return sequencers, nil
 }
 
 func (c *HubClient) saveBatch(batch *settlement.Batch) {


### PR DESCRIPTION
This PR updates the NewManager function, adding only the proposer as a validator in the init chian

Closes #603 
# PR Standards

## Opening a pull request should be able to meet the following requirements

---

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
