### PR TITLE
style: rename local hub settlement to local instead of mock

### DIFF
--- a/block/manager_test.go
+++ b/block/manager_test.go
@@ -43,7 +43,7 @@ func TestInitialState(t *testing.T) {
 	err = pubsubServer.Start()
 	require.NoError(t, err)
 	proxyApp := testutil.GetABCIProxyAppMock(logger.With("module", "proxy"))
-	settlementlc := slregistry.GetClient(slregistry.Mock)
+	settlementlc := slregistry.GetClient(slregistry.Local)
 	_ = settlementlc.Init(settlement.Config{}, pubsubServer, logger)
 
 	// Init empty store and full store

--- a/block/testutil.go
+++ b/block/testutil.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/dymensionxyz/dymint/config"
 	"github.com/dymensionxyz/dymint/da"
-	mockda "github.com/dymensionxyz/dymint/da/mock"
+	localda "github.com/dymensionxyz/dymint/da/local"
 	mempoolv1 "github.com/dymensionxyz/dymint/mempool/v1"
 	nodemempool "github.com/dymensionxyz/dymint/node/mempool"
 	slregistry "github.com/dymensionxyz/dymint/settlement/registry"
@@ -72,7 +72,7 @@ func getManagerWithProposerKey(conf config.BlockManagerConfig, proposerKey crypt
 	}
 
 	if dalc == nil {
-		dalc = &mockda.DataAvailabilityLayerClient{}
+		dalc = &localda.DataAvailabilityLayerClient{}
 	}
 	initDALCMock(dalc, pubsubServer, logger)
 
@@ -123,7 +123,7 @@ func getManager(conf config.BlockManagerConfig, settlementlc settlement.LayerI, 
 
 // TODO(omritoptix): Possible move out to a generic testutil
 func getMockDALC(logger log.Logger) da.DataAvailabilityLayerClient {
-	dalc := &mockda.DataAvailabilityLayerClient{}
+	dalc := &localda.DataAvailabilityLayerClient{}
 	initDALCMock(dalc, pubsub.NewServer(), logger)
 	return dalc
 }

--- a/block/testutil.go
+++ b/block/testutil.go
@@ -57,7 +57,7 @@ func getManagerWithProposerKey(conf config.BlockManagerConfig, proposerKey crypt
 
 	// Init the settlement layer mock
 	if settlementlc == nil {
-		settlementlc = slregistry.GetClient(slregistry.Mock)
+		settlementlc = slregistry.GetClient(slregistry.Local)
 	}
 
 	proposerPubKey := proposerKey.GetPublic()

--- a/da/celestia/mock/server.go
+++ b/da/celestia/mock/server.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/celestiaorg/go-cnc"
 	"github.com/dymensionxyz/dymint/da"
-	mockda "github.com/dymensionxyz/dymint/da/mock"
+	"github.com/dymensionxyz/dymint/da/local"
 	"github.com/dymensionxyz/dymint/log"
 	"github.com/dymensionxyz/dymint/store"
 	"github.com/dymensionxyz/dymint/types"
@@ -23,7 +23,7 @@ import (
 
 // Server mocks celestia-node HTTP API.
 type Server struct {
-	mock      *mockda.DataAvailabilityLayerClient
+	mock      *local.DataAvailabilityLayerClient
 	blockTime time.Duration
 	server    *http.Server
 	logger    log.Logger
@@ -32,7 +32,7 @@ type Server struct {
 // NewServer creates new instance of Server.
 func NewServer(blockTime time.Duration, logger log.Logger) *Server {
 	return &Server{
-		mock:      new(mockda.DataAvailabilityLayerClient),
+		mock:      new(local.DataAvailabilityLayerClient),
 		blockTime: blockTime,
 		logger:    logger,
 	}

--- a/da/celestia/mock/server.go
+++ b/da/celestia/mock/server.go
@@ -23,7 +23,7 @@ import (
 
 // Server mocks celestia-node HTTP API.
 type Server struct {
-	mock      *local.DataAvailabilityLayerClient
+	da        *local.DataAvailabilityLayerClient
 	blockTime time.Duration
 	server    *http.Server
 	logger    log.Logger
@@ -32,7 +32,7 @@ type Server struct {
 // NewServer creates new instance of Server.
 func NewServer(blockTime time.Duration, logger log.Logger) *Server {
 	return &Server{
-		mock:      new(local.DataAvailabilityLayerClient),
+		da:        new(local.DataAvailabilityLayerClient),
 		blockTime: blockTime,
 		logger:    logger,
 	}
@@ -40,11 +40,11 @@ func NewServer(blockTime time.Duration, logger log.Logger) *Server {
 
 // Start starts HTTP server with given listener.
 func (s *Server) Start(listener net.Listener) error {
-	err := s.mock.Init([]byte(s.blockTime.String()), pubsub.NewServer(), store.NewDefaultInMemoryKVStore(), s.logger)
+	err := s.da.Init([]byte(s.blockTime.String()), pubsub.NewServer(), store.NewDefaultInMemoryKVStore(), s.logger)
 	if err != nil {
 		return err
 	}
-	err = s.mock.Start()
+	err = s.da.Start()
 	if err != nil {
 		return err
 	}
@@ -93,7 +93,7 @@ func (s *Server) submit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	res := s.mock.SubmitBatch(&batch)
+	res := s.da.SubmitBatch(&batch)
 	code := 0
 	if res.Code != da.StatusSuccess {
 		code = 3
@@ -122,7 +122,7 @@ func (s *Server) shares(w http.ResponseWriter, r *http.Request) {
 	daMetaData := &da.DASubmitMetaData{
 		Height: height,
 	}
-	res := s.mock.RetrieveBatches(daMetaData)
+	res := s.da.RetrieveBatches(daMetaData)
 	if res.Code != da.StatusSuccess {
 		s.writeError(w, errors.New(res.Message))
 		return
@@ -167,7 +167,7 @@ func (s *Server) data(w http.ResponseWriter, r *http.Request) {
 	daMetaData := &da.DASubmitMetaData{
 		Height: height,
 	}
-	res := s.mock.RetrieveBatches(daMetaData)
+	res := s.da.RetrieveBatches(daMetaData)
 	if res.Code != da.StatusSuccess {
 		s.writeError(w, errors.New(res.Message))
 		return

--- a/da/da_test.go
+++ b/da/da_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/dymensionxyz/dymint/da"
 	"github.com/dymensionxyz/dymint/da/celestia"
-	"github.com/dymensionxyz/dymint/da/mock"
+	"github.com/dymensionxyz/dymint/da/local"
 	"github.com/dymensionxyz/dymint/da/registry"
 	"github.com/dymensionxyz/dymint/store"
 	"github.com/dymensionxyz/dymint/types"
@@ -59,11 +59,11 @@ func doTestDALC(t *testing.T, mockDalc da.DataAvailabilityLayerClient) {
 	var err error
 
 	// mock DALC will advance block height every 100ms
-	if _, ok := mockDalc.(*mock.DataAvailabilityLayerClient); !ok {
-		t.Fatal("mock DALC is not of type *mock.DataAvailabilityLayerClient")
+	if _, ok := mockDalc.(*local.DataAvailabilityLayerClient); !ok {
+		t.Fatal("mock DALC is not of type *local.DataAvailabilityLayerClient")
 	}
 	conf := []byte(mockDaBlockTime.String())
-	dalc := mockDalc.(*mock.DataAvailabilityLayerClient)
+	dalc := mockDalc.(*local.DataAvailabilityLayerClient)
 
 	pubsubServer := pubsub.NewServer()
 	err = pubsubServer.Start()
@@ -132,7 +132,7 @@ func doTestRetrieve(t *testing.T, dalc da.DataAvailabilityLayerClient) {
 
 	// mock DALC will advance block height every 100ms
 	conf := []byte{}
-	if _, ok := dalc.(*mock.DataAvailabilityLayerClient); ok {
+	if _, ok := dalc.(*local.DataAvailabilityLayerClient); ok {
 		conf = []byte(mockDaBlockTime.String())
 	}
 	if _, ok := dalc.(*celestia.DataAvailabilityLayerClient); ok {

--- a/da/grpc/mockserv/mockserv.go
+++ b/da/grpc/mockserv/mockserv.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/dymensionxyz/dymint/da"
 	grpcda "github.com/dymensionxyz/dymint/da/grpc"
-	"github.com/dymensionxyz/dymint/da/mock"
+	"github.com/dymensionxyz/dymint/da/local"
 	"github.com/dymensionxyz/dymint/store"
 	"github.com/dymensionxyz/dymint/types"
 	"github.com/dymensionxyz/dymint/types/pb/dalc"
@@ -38,7 +38,7 @@ func GetServer(kv store.KVStore, conf grpcda.Config, mockConfig []byte) *grpc.Se
 }
 
 type mockImpl struct {
-	mock mock.DataAvailabilityLayerClient
+	mock local.DataAvailabilityLayerClient
 }
 
 func (m *mockImpl) SubmitBatch(_ context.Context, request *dalc.SubmitBatchRequest) (*dalc.SubmitBatchResponse, error) {

--- a/da/grpc/mockserv/mockserv.go
+++ b/da/grpc/mockserv/mockserv.go
@@ -23,12 +23,12 @@ func GetServer(kv store.KVStore, conf grpcda.Config, mockConfig []byte) *grpc.Se
 
 	srv := grpc.NewServer()
 	mockImpl := &mockImpl{}
-	err := mockImpl.mock.Init(mockConfig, pubsub.NewServer(), kv, logger)
+	err := mockImpl.da.Init(mockConfig, pubsub.NewServer(), kv, logger)
 	if err != nil {
 		logger.Error("failed to initialize mock DALC", "error", err)
 		panic(err)
 	}
-	err = mockImpl.mock.Start()
+	err = mockImpl.da.Start()
 	if err != nil {
 		logger.Error("failed to start mock DALC", "error", err)
 		panic(err)
@@ -38,7 +38,7 @@ func GetServer(kv store.KVStore, conf grpcda.Config, mockConfig []byte) *grpc.Se
 }
 
 type mockImpl struct {
-	mock local.DataAvailabilityLayerClient
+	da local.DataAvailabilityLayerClient
 }
 
 func (m *mockImpl) SubmitBatch(_ context.Context, request *dalc.SubmitBatchRequest) (*dalc.SubmitBatchResponse, error) {
@@ -47,7 +47,7 @@ func (m *mockImpl) SubmitBatch(_ context.Context, request *dalc.SubmitBatchReque
 	if err != nil {
 		return nil, err
 	}
-	resp := m.mock.SubmitBatch(&b)
+	resp := m.da.SubmitBatch(&b)
 	return &dalc.SubmitBatchResponse{
 		Result: &dalc.DAResponse{
 			Code:            dalc.StatusCode(resp.Code),
@@ -62,7 +62,7 @@ func (m *mockImpl) CheckBatchAvailability(_ context.Context, request *dalc.Check
 	daMetaData := &da.DASubmitMetaData{
 		Height: request.DataLayerHeight,
 	}
-	resp := m.mock.CheckBatchAvailability(daMetaData)
+	resp := m.da.CheckBatchAvailability(daMetaData)
 	return &dalc.CheckBatchAvailabilityResponse{
 		Result: &dalc.DAResponse{
 			Code:    dalc.StatusCode(resp.Code),
@@ -75,7 +75,7 @@ func (m *mockImpl) RetrieveBatches(context context.Context, request *dalc.Retrie
 	dataMetaData := &da.DASubmitMetaData{
 		Height: request.DataLayerHeight,
 	}
-	resp := m.mock.RetrieveBatches(dataMetaData)
+	resp := m.da.RetrieveBatches(dataMetaData)
 	batches := make([]*dymint.Batch, len(resp.Batches))
 	for i := range resp.Batches {
 		batches[i] = resp.Batches[i].ToProto()

--- a/da/local/local.go
+++ b/da/local/local.go
@@ -1,4 +1,4 @@
-package mock
+package local
 
 import (
 	"crypto/sha1" //#nosec

--- a/da/registry/registry.go
+++ b/da/registry/registry.go
@@ -5,12 +5,12 @@ import (
 	"github.com/dymensionxyz/dymint/da/avail"
 	"github.com/dymensionxyz/dymint/da/celestia"
 	"github.com/dymensionxyz/dymint/da/grpc"
-	"github.com/dymensionxyz/dymint/da/mock"
+	"github.com/dymensionxyz/dymint/da/local"
 )
 
 // this is a central registry for all Data Availability Layer Clients
 var clients = map[string]func() da.DataAvailabilityLayerClient{
-	"mock":     func() da.DataAvailabilityLayerClient { return &mock.DataAvailabilityLayerClient{} },
+	"mock":     func() da.DataAvailabilityLayerClient { return &local.DataAvailabilityLayerClient{} },
 	"grpc":     func() da.DataAvailabilityLayerClient { return &grpc.DataAvailabilityLayerClient{} },
 	"celestia": func() da.DataAvailabilityLayerClient { return &celestia.DataAvailabilityLayerClient{} },
 	"avail":    func() da.DataAvailabilityLayerClient { return &avail.DataAvailabilityLayerClient{} },

--- a/settlement/local/local.go
+++ b/settlement/local/local.go
@@ -1,4 +1,4 @@
-package mock
+package local
 
 import (
 	"context"

--- a/settlement/registry/registry.go
+++ b/settlement/registry/registry.go
@@ -4,15 +4,15 @@ import (
 	"github.com/dymensionxyz/dymint/settlement"
 	"github.com/dymensionxyz/dymint/settlement/dymension"
 	"github.com/dymensionxyz/dymint/settlement/grpc"
-	"github.com/dymensionxyz/dymint/settlement/mock"
+	"github.com/dymensionxyz/dymint/settlement/local"
 )
 
 // Client represents a settlement layer client
 type Client string
 
 const (
-	// Mock is a mock client for the settlement layer
-	Mock Client = "mock"
+	// Local is a mock client for the settlement layer
+	Local Client = "mock"
 	// Dymension is a client for interacting with dymension settlement layer
 	Dymension Client = "dymension"
 	// Mock client using grpc for a shared use
@@ -21,7 +21,7 @@ const (
 
 // A central registry for all Settlement Layer Clients
 var clients = map[Client]func() settlement.LayerI{
-	Mock:      func() settlement.LayerI { return &mock.LayerClient{} },
+	Local:     func() settlement.LayerI { return &local.LayerClient{} },
 	Dymension: func() settlement.LayerI { return &dymension.LayerClient{} },
 	Grpc:      func() settlement.LayerI { return &grpc.LayerClient{} },
 }

--- a/settlement/registry/registry_test.go
+++ b/settlement/registry/registry_test.go
@@ -10,7 +10,7 @@ import (
 func TestRegistery(t *testing.T) {
 	assert := assert.New(t)
 
-	expected := []registry.Client{registry.Mock, registry.Dymension, registry.Grpc}
+	expected := []registry.Client{registry.Local, registry.Dymension, registry.Grpc}
 	actual := registry.RegisteredClients()
 
 	assert.ElementsMatch(expected, actual)

--- a/settlement/settlement_test.go
+++ b/settlement/settlement_test.go
@@ -25,7 +25,7 @@ const batchSize = 5
 
 func TestLifecycle(t *testing.T) {
 	var err error
-	client := registry.GetClient(registry.Mock)
+	client := registry.GetClient(registry.Local)
 	require := require.New(t)
 
 	pubsubServer := pubsub.NewServer()
@@ -45,7 +45,7 @@ func TestSubmitAndRetrieve(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
-	settlementClient := registry.GetClient(registry.Mock)
+	settlementClient := registry.GetClient(registry.Local)
 
 	initClient(t, settlementClient)
 
@@ -99,7 +99,7 @@ func TestSubmitAndRetrieve(t *testing.T) {
 
 func TestGetSequencersEmptyList(t *testing.T) {
 	var err error
-	settlementClient := registry.GetClient(registry.Mock)
+	settlementClient := registry.GetClient(registry.Local)
 	hubClientMock := mocks.NewHubClient(t)
 	hubClientMock.On("GetSequencers", tsmock.Anything, tsmock.Anything).Return(nil, settlement.ErrNoSequencerForRollapp)
 	options := []settlement.Option{
@@ -125,7 +125,7 @@ func TestGetSequencers(t *testing.T) {
 	options := []settlement.Option{
 		settlement.WithHubClient(hubClientMock),
 	}
-	settlementClient := registry.GetClient(registry.Mock)
+	settlementClient := registry.GetClient(registry.Local)
 	initClient(t, settlementClient, options...)
 
 	sequencersList := settlementClient.GetSequencersList()

--- a/testutil/mocks.go
+++ b/testutil/mocks.go
@@ -11,7 +11,7 @@ import (
 	"github.com/tendermint/tendermint/proxy"
 
 	"github.com/dymensionxyz/dymint/da"
-	mockda "github.com/dymensionxyz/dymint/da/mock"
+	localda "github.com/dymensionxyz/dymint/da/local"
 	"github.com/dymensionxyz/dymint/store"
 )
 
@@ -137,7 +137,7 @@ const connectionRefusedErrorMessage = "connection refused"
 
 // DALayerClientSubmitBatchError is a mock data availability layer client that can be used to test error handling
 type DALayerClientSubmitBatchError struct {
-	mockda.DataAvailabilityLayerClient
+	localda.DataAvailabilityLayerClient
 }
 
 // SubmitBatch submits a batch to the data availability layer
@@ -147,7 +147,7 @@ func (s *DALayerClientSubmitBatchError) SubmitBatch(_ *types.Batch) da.ResultSub
 
 // DALayerClientRetrieveBatchesError is a mock data availability layer client that can be used to test error handling
 type DALayerClientRetrieveBatchesError struct {
-	mockda.DataAvailabilityLayerClient
+	localda.DataAvailabilityLayerClient
 }
 
 // RetrieveBatches retrieves batches from the data availability layer


### PR DESCRIPTION
to avoid compatibility issues, I've left it as `"mock"` in the configuration files.

On the source code, the local hub and local da are now called `local` instead of `mock`.


# PR Standards

## Opening a pull request should be able to meet the following requirements

---

Close #XXX

<-- Briefly describe the content of this pull request -->

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
