### PR TITLE
fix: celestia wrong error log for availability checks and retrievals

### DIFF
--- a/da/celestia/celestia.go
+++ b/da/celestia/celestia.go
@@ -288,8 +288,9 @@ func (c *DataAvailabilityLayerClient) RetrieveBatches(daMetaData *da.DASubmitMet
 
 				return nil
 			}, retry.Attempts(uint(c.rpcRetryAttempts)), retry.DelayType(retry.FixedDelay), retry.Delay(c.rpcRetryDelay))
-			c.logger.Error("RetrieveBatches process failed", "error", err)
-
+			if err != nil {
+				c.logger.Error("RetrieveBatches process failed", "error", err)
+			}
 			return resultRetrieveBatch
 
 		}
@@ -415,7 +416,9 @@ func (c *DataAvailabilityLayerClient) CheckBatchAvailability(daMetaData *da.DASu
 
 				return nil
 			}, retry.Attempts(uint(c.rpcRetryAttempts)), retry.DelayType(retry.FixedDelay), retry.Delay(c.rpcRetryDelay))
-			c.logger.Error("CheckAvailability process failed", "error", err)
+			if err != nil {
+				c.logger.Error("CheckAvailability process failed", "error", err)
+			}
 			return availabilityResult
 		}
 	}


### PR DESCRIPTION
# PR Standards
---

This is a fix to log an error only when there is actually an error in the RetrieveBatches and CheckBatchAvailability funcs for the celestia da, since now the msg is always logged.


Close #644 

<-- Briefly describe the content of this pull request -->

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
