### PR TITLE
fix: full-node panics with app hash mismatch error when syncing

### DIFF
--- a/block/manager.go
+++ b/block/manager.go
@@ -148,15 +148,17 @@ func (m *Manager) Start(ctx context.Context, isAggregator bool) error {
 			return fmt.Errorf("proposer key mismatch: settlement proposer key: %s, block manager proposer key: %s", slProposerKey, m.proposerKey.GetPublic())
 		}
 		m.logger.Info("Starting in aggregator mode")
+	}
 
-		// Check if InitChain flow is needed
-		if m.lastState.LastBlockHeight+1 == m.genesis.InitialHeight {
-			err := m.RunInitChain(ctx)
-			if err != nil {
-				return err
-			}
+	// Check if InitChain flow is needed
+	if m.lastState.LastBlockHeight+1 == m.genesis.InitialHeight {
+		err := m.RunInitChain(ctx)
+		if err != nil {
+			return err
 		}
+	}
 
+	if isAggregator {
 		go m.ProduceBlockLoop(ctx)
 		go m.SubmitLoop(ctx)
 	} else {

--- a/block/manager.go
+++ b/block/manager.go
@@ -134,12 +134,6 @@ func NewManager(
 func (m *Manager) Start(ctx context.Context, isAggregator bool) error {
 	m.logger.Info("Starting the block manager")
 
-	err := m.syncBlockManager(ctx)
-	if err != nil {
-		err = fmt.Errorf("failed to sync block manager: %w", err)
-		return err
-	}
-
 	if isAggregator {
 		//make sure local signing key is the registered on the hub
 		slProposerKey := m.settlementClient.GetProposer().PublicKey.Bytes()
@@ -156,6 +150,12 @@ func (m *Manager) Start(ctx context.Context, isAggregator bool) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	err := m.syncBlockManager(ctx)
+	if err != nil {
+		err = fmt.Errorf("failed to sync block manager: %w", err)
+		return err
 	}
 
 	if isAggregator {

--- a/rpc/client/client_test.go
+++ b/rpc/client/client_test.go
@@ -144,6 +144,7 @@ func TestBroadcastTxAsync(t *testing.T) {
 
 	mockApp, rpc := getRPC(t)
 	mockApp.On("CheckTx", abci.RequestCheckTx{Tx: expectedTx}).Return(abci.ResponseCheckTx{})
+	mockApp.On("InitChain", mock.Anything).Return(abci.ResponseInitChain{})
 
 	err := rpc.node.Start()
 	require.NoError(t, err)
@@ -178,6 +179,7 @@ func TestBroadcastTxSync(t *testing.T) {
 	}
 
 	mockApp, rpc := getRPC(t)
+	mockApp.On("InitChain", mock.Anything).Return(abci.ResponseInitChain{})
 
 	err := rpc.node.Start()
 	require.NoError(t, err)
@@ -228,7 +230,7 @@ func TestBroadcastTxCommit(t *testing.T) {
 	mockApp.On("BeginBlock", mock.Anything).Return(abci.ResponseBeginBlock{})
 	mockApp.BeginBlock(abci.RequestBeginBlock{})
 	mockApp.On("CheckTx", abci.RequestCheckTx{Tx: expectedTx}).Return(expectedCheckResp)
-
+	mockApp.On("InitChain", mock.Anything).Return(abci.ResponseInitChain{})
 	// in order to broadcast, the node must be started
 	err := rpc.node.Start()
 	require.NoError(err)
@@ -264,6 +266,7 @@ func TestGetBlock(t *testing.T) {
 	mockApp.On("CheckTx", mock.Anything).Return(abci.ResponseCheckTx{})
 	mockApp.On("EndBlock", mock.Anything).Return(abci.ResponseEndBlock{})
 	mockApp.On("Commit", mock.Anything).Return(abci.ResponseCommit{})
+	mockApp.On("InitChain", mock.Anything).Return(abci.ResponseInitChain{})
 
 	err := rpc.node.Start()
 	require.NoError(err)
@@ -289,6 +292,7 @@ func TestGetCommit(t *testing.T) {
 	mockApp, rpc := getRPC(t)
 	mockApp.On("BeginBlock", mock.Anything).Return(abci.ResponseBeginBlock{})
 	mockApp.On("Commit", mock.Anything).Return(abci.ResponseCommit{})
+	mockApp.On("InitChain", mock.Anything).Return(abci.ResponseInitChain{})
 
 	blocks := []*types.Block{getRandomBlock(1, 5), getRandomBlock(2, 6), getRandomBlock(3, 8), getRandomBlock(4, 10)}
 
@@ -391,6 +395,7 @@ func TestGetBlockByHash(t *testing.T) {
 	mockApp.On("EndBlock", mock.Anything).Return(abci.ResponseEndBlock{})
 	mockApp.On("Commit", mock.Anything).Return(abci.ResponseCommit{})
 	mockApp.On("Info", mock.Anything).Return(abci.ResponseInfo{LastBlockHeight: 0, LastBlockAppHash: []byte{0}})
+	mockApp.On("InitChain", mock.Anything).Return(abci.ResponseInitChain{})
 
 	err := rpc.node.Start()
 	require.NoError(err)
@@ -507,6 +512,7 @@ func TestUnconfirmedTxs(t *testing.T) {
 			mockApp, rpc := getRPC(t)
 			mockApp.On("BeginBlock", mock.Anything).Return(abci.ResponseBeginBlock{})
 			mockApp.On("CheckTx", mock.Anything).Return(abci.ResponseCheckTx{})
+			mockApp.On("InitChain", mock.Anything).Return(abci.ResponseInitChain{})
 
 			err := rpc.node.Start()
 			require.NoError(err)


### PR DESCRIPTION
# PR Standards
---
This PR solves the issue running the RunInitChain func for botch sequencers and full-nodes to update the lastState, and starts syncing after that.


Close #643 

<-- Briefly describe the content of this pull request -->

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
