### PR TITLE
fix(da): full-node get the da fetch configuration from hub and not config

### DIFF
--- a/da/celestia/celestia.go
+++ b/da/celestia/celestia.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"slices"
 	"time"
 
 	"github.com/avast/retry-go/v4"
@@ -400,17 +399,6 @@ func (c *DataAvailabilityLayerClient) retrieveBatchesNoCommitment(dataLayerHeigh
 
 func (c *DataAvailabilityLayerClient) CheckBatchAvailability(daMetaData *da.DASubmitMetaData) da.ResultCheckBatch {
 	var availabilityResult da.ResultCheckBatch
-	//check namespace
-	if !slices.Equal(daMetaData.Namespace, c.config.NamespaceID.Bytes()) {
-		return da.ResultCheckBatch{
-			BaseResult: da.BaseResult{
-				Code:    da.StatusError,
-				Message: fmt.Sprintf("namespace not matching: daMetaData %v: config: %v", daMetaData.Namespace, c.config.NamespaceID.Bytes()),
-				Error:   da.ErrNameSpace,
-			},
-			CheckMetaData: &da.DACheckMetaData{},
-		}
-	}
 	for {
 		select {
 		case <-c.ctx.Done():

--- a/da/celestia/celestia.go
+++ b/da/celestia/celestia.go
@@ -427,11 +427,12 @@ func (c *DataAvailabilityLayerClient) CheckBatchAvailability(daMetaData *da.DASu
 func (c *DataAvailabilityLayerClient) checkBatchAvailability(daMetaData *da.DASubmitMetaData) da.ResultCheckBatch {
 	var proofs []*blob.Proof
 
-	DACheckMetaData := &da.DACheckMetaData{}
-	DACheckMetaData.Height = daMetaData.Height
-	DACheckMetaData.Client = daMetaData.Client
-	DACheckMetaData.Commitment = daMetaData.Commitment
-	DACheckMetaData.Namespace = daMetaData.Namespace
+	DACheckMetaData := &da.DACheckMetaData{
+		Client:     daMetaData.Client,
+		Height:     daMetaData.Height,
+		Commitment: daMetaData.Commitment,
+		Namespace:  daMetaData.Namespace,
+	}
 
 	dah, err := c.getDataAvailabilityHeaders(daMetaData.Height)
 	if err != nil {

--- a/da/celestia/celestia_test.go
+++ b/da/celestia/celestia_test.go
@@ -254,21 +254,6 @@ func TestAvalabilityWrongProof(t *testing.T) {
 	assert.ErrorIs(availRes.Error, da.ErrUnableToGetProof)
 }
 
-func TestRetrievalWrongNamespace(t *testing.T) {
-	assert := assert.New(t)
-
-	_, dalc, _, _ := setDAandMock(t)
-
-	retriever := dalc.(da.BatchRetriever)
-
-	h1 := &da.DASubmitMetaData{
-		Height: 1,
-	}
-
-	availRes := retriever.CheckBatchAvailability(h1)
-	assert.ErrorIs(availRes.Error, da.ErrNameSpace)
-}
-
 func TestRetrievalWrongCommitment(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -288,9 +273,9 @@ func TestRetrievalWrongCommitment(t *testing.T) {
 		Commitment: commitment,
 		Namespace:  namespace,
 	}
-	retreiveRes := retriever.RetrieveBatches(h1)
-	assert.ErrorIs(retreiveRes.Error, da.ErrBlobNotFound)
-	require.True(len(retreiveRes.Batches) == 0)
+	retrieveRes := retriever.RetrieveBatches(h1)
+	assert.ErrorIs(retrieveRes.Error, da.ErrBlobNotFound)
+	require.True(len(retrieveRes.Batches) == 0)
 
 	mockRPCClient.On("GetProof", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil).Once().Run(func(args mock.Arguments) { time.Sleep(10 * time.Millisecond) })
 	mockRPCClient.On("GetHeaders", mock.Anything, mock.Anything).Return(headers, nil).Once().Run(func(args mock.Arguments) { time.Sleep(10 * time.Millisecond) })


### PR DESCRIPTION
# PR Standards

This is a code refactor to avoid using namespace id param from configuration in full-nodes, since it is not relevant and it can lead to potential config issues, and the important is the namespace used by sequencer when posting batches.

## Opening a pull request should be able to meet the following requirements

---

Close #718 

<-- Briefly describe the content of this pull request -->

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
