### PR TITLE
fix(p2p): validate block before applying and not before caching in p2p gossiping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# [](https://github.com/dymensionxyz/dymint/compare/v1.1.0-rc01...v) (2024-04-26)
+# [](https://github.com/dymensionxyz/dymint/compare/v1.1.0-rc02...v) (2024-04-26)
+
+
+
+# [1.1.0-rc02](https://github.com/dymensionxyz/dymint/compare/v1.1.0-rc01...v1.1.0-rc02) (2024-04-26)
 
 
 

--- a/block/block.go
+++ b/block/block.go
@@ -130,6 +130,11 @@ func (m *Manager) attemptApplyCachedBlocks() error {
 		if !blockExists {
 			break
 		}
+		if err := m.validateBlock(cachedBlock.Block, cachedBlock.Commit); err != nil {
+			m.logger.Error("apply cached block, block not valid: dropping it", "err", err, "height", cachedBlock.Block.Header.Height)
+			/// TODO: can we take an action here such as dropping the peer / reducing their reputation?
+			return err
+		}
 
 		// Note: cached <block,commit> pairs have passed basic validation, so no need to validate again
 		err := m.applyBlock(cachedBlock.Block, cachedBlock.Commit, blockMetaData{source: gossipedBlock})

--- a/block/block.go
+++ b/block/block.go
@@ -131,10 +131,9 @@ func (m *Manager) attemptApplyCachedBlocks() error {
 			break
 		}
 		if err := m.validateBlock(cachedBlock.Block, cachedBlock.Commit); err != nil {
-			m.logger.Error("apply cached block, block not valid: dropping it", "err", err, "height", cachedBlock.Block.Header.Height)
 			delete(m.blockCache, cachedBlock.Block.Header.Height)
 			/// TODO: can we take an action here such as dropping the peer / reducing their reputation?
-			return err
+			return fmt.Errorf("block not valid at height %d, dropping it: err:%w", cachedBlock.Block.Header.Height, err)
 		}
 
 		err := m.applyBlock(cachedBlock.Block, cachedBlock.Commit, blockMetaData{source: gossipedBlock})

--- a/block/block.go
+++ b/block/block.go
@@ -132,6 +132,7 @@ func (m *Manager) attemptApplyCachedBlocks() error {
 		}
 		if err := m.validateBlock(cachedBlock.Block, cachedBlock.Commit); err != nil {
 			m.logger.Error("apply cached block, block not valid: dropping it", "err", err, "height", cachedBlock.Block.Header.Height)
+			delete(m.blockCache, cachedBlock.Block.Header.Height)
 			/// TODO: can we take an action here such as dropping the peer / reducing their reputation?
 			return err
 		}

--- a/block/block.go
+++ b/block/block.go
@@ -136,7 +136,6 @@ func (m *Manager) attemptApplyCachedBlocks() error {
 			return err
 		}
 
-		// Note: cached <block,commit> pairs have passed basic validation, so no need to validate again
 		err := m.applyBlock(cachedBlock.Block, cachedBlock.Commit, blockMetaData{source: gossipedBlock})
 		if err != nil {
 			return fmt.Errorf("apply cached block: expected height: %d: %w", expectedHeight, err)

--- a/block/manager.go
+++ b/block/manager.go
@@ -243,12 +243,6 @@ func (m *Manager) onNewGossipedBlock(event pubsub.Message) {
 	block := eventData.Block
 	commit := eventData.Commit
 
-	if err := m.validateBlock(&block, &commit); err != nil {
-		m.logger.Error("apply block callback, block not valid: dropping it", "err", err, "height", block.Header.Height)
-		/// TODO: can we take an action here such as dropping the peer / reducing their reputation?
-		return
-	}
-
 	nextHeight := m.Store.NextHeight()
 	if block.Header.Height >= nextHeight {
 		m.blockCache[block.Header.Height] = CachedBlock{


### PR DESCRIPTION
# PR Standards

P2P gossiping tries to validate blocks on reception. However, the validation fails if blocks are received unordered, dropping them, and being unable to sync using p2p for any block received after. This PR fixes the issue validating blocks in order, moving the validation call after caching them, and before applying, once all blocks are received and can be applied in order.

## Opening a pull request should be able to meet the following requirements

---

Close #722 

<-- Briefly describe the content of this pull request -->

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
