### PR TITLE
feat(p2p): moving gossiped blocks reception from validator to p2p client

### DIFF
--- a/block/manager.go
+++ b/block/manager.go
@@ -241,10 +241,10 @@ func (m *Manager) onNodeHealthStatus(event pubsub.Message) {
 // onNewGossippedBlock will take a block and apply it
 func (m *Manager) onNewGossipedBlock(event pubsub.Message) {
 	m.retrieverMutex.Lock() // needed to protect blockCache access
-	m.logger.Debug("Received new block via gossip", "n cachedBlocks", len(m.blockCache))
 	eventData := event.Data().(p2p.GossipedBlock)
 	block := eventData.Block
 	commit := eventData.Commit
+	m.logger.Debug("Received new block via gossip", "height", block.Header.Height, "n cachedBlocks", len(m.blockCache))
 
 	nextHeight := m.Store.NextHeight()
 	if block.Header.Height >= nextHeight {

--- a/block/manager.go
+++ b/block/manager.go
@@ -240,19 +240,13 @@ func (m *Manager) onNodeHealthStatus(event pubsub.Message) {
 // TODO: move to gossip.go
 // onNewGossippedBlock will take a block and apply it
 func (m *Manager) onNewGossipedBlock(event pubsub.Message) {
+	m.retrieverMutex.Lock() // needed to protect blockCache access
 	eventData := event.Data().(p2p.GossipedBlock)
 	block := eventData.Block
 	commit := eventData.Commit
 	m.logger.Debug("Received new block via gossip", "height", block.Header.Height, "n cachedBlocks", len(m.blockCache))
 
 	nextHeight := m.Store.NextHeight()
-
-	_, found := m.blockCache[block.Header.Height]
-	if found {
-		return
-	}
-	m.retrieverMutex.Lock() // needed to protect blockCache access
-
 	if block.Header.Height >= nextHeight {
 		m.blockCache[block.Header.Height] = CachedBlock{
 			Block:  &block,

--- a/block/manager.go
+++ b/block/manager.go
@@ -240,13 +240,19 @@ func (m *Manager) onNodeHealthStatus(event pubsub.Message) {
 // TODO: move to gossip.go
 // onNewGossippedBlock will take a block and apply it
 func (m *Manager) onNewGossipedBlock(event pubsub.Message) {
-	m.retrieverMutex.Lock() // needed to protect blockCache access
 	eventData := event.Data().(p2p.GossipedBlock)
 	block := eventData.Block
 	commit := eventData.Commit
 	m.logger.Debug("Received new block via gossip", "height", block.Header.Height, "n cachedBlocks", len(m.blockCache))
 
 	nextHeight := m.Store.NextHeight()
+
+	_, found := m.blockCache[block.Header.Height]
+	if found {
+		return
+	}
+	m.retrieverMutex.Lock() // needed to protect blockCache access
+
 	if block.Header.Height >= nextHeight {
 		m.blockCache[block.Header.Height] = CachedBlock{
 			Block:  &block,

--- a/block/manager_test.go
+++ b/block/manager_test.go
@@ -57,7 +57,7 @@ func TestInitialState(t *testing.T) {
 	p2pClient, err := p2p.NewClient(config.P2PConfig{
 		GossipCacheSize: 50,
 		BoostrapTime:    30 * time.Second,
-	}, privKey, "TestChain", logger)
+	}, privKey, "TestChain", pubsubServer, logger)
 	assert.NoError(err)
 	assert.NotNil(p2pClient)
 

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -34,7 +34,7 @@ func DefaultConfig(home, chainId string) *NodeConfig {
 			NamespaceID:             "0000000000000000ffff",
 			BlockBatchSize:          500,
 			BlockBatchMaxSizeBytes:  500000,
-			GossipedBlocksCacheSize: 5000,
+			GossipedBlocksCacheSize: 50,
 		},
 		DALayer:         "mock",
 		SettlementLayer: "mock",

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -34,7 +34,7 @@ func DefaultConfig(home, chainId string) *NodeConfig {
 			NamespaceID:             "0000000000000000ffff",
 			BlockBatchSize:          500,
 			BlockBatchMaxSizeBytes:  500000,
-			GossipedBlocksCacheSize: 50,
+			GossipedBlocksCacheSize: 5000,
 		},
 		DALayer:         "mock",
 		SettlementLayer: "mock",

--- a/node/node.go
+++ b/node/node.go
@@ -206,7 +206,7 @@ func NewNode(
 
 	conf.P2P.GossipCacheSize = conf.BlockManagerConfig.GossipedBlocksCacheSize
 	conf.P2P.BoostrapTime = conf.BootstrapTime
-	p2pClient, err := p2p.NewClient(conf.P2P, p2pKey, genesis.ChainID, conf.blockTime, pubsubServer, logger.With("module", "p2p"))
+	p2pClient, err := p2p.NewClient(conf.P2P, p2pKey, genesis.ChainID, pubsubServer, logger.With("module", "p2p"))
 	if err != nil {
 		return nil, err
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -206,7 +206,7 @@ func NewNode(
 
 	conf.P2P.GossipCacheSize = conf.BlockManagerConfig.GossipedBlocksCacheSize
 	conf.P2P.BoostrapTime = conf.BootstrapTime
-	p2pClient, err := p2p.NewClient(conf.P2P, p2pKey, genesis.ChainID, conf.BlockTime, pubsubServer, logger.With("module", "p2p"))
+	p2pClient, err := p2p.NewClient(conf.P2P, p2pKey, genesis.ChainID, conf.blockTime, pubsubServer, logger.With("module", "p2p"))
 	if err != nil {
 		return nil, err
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -206,7 +206,7 @@ func NewNode(
 
 	conf.P2P.GossipCacheSize = conf.BlockManagerConfig.GossipedBlocksCacheSize
 	conf.P2P.BoostrapTime = conf.BootstrapTime
-	p2pClient, err := p2p.NewClient(conf.P2P, p2pKey, genesis.ChainID, pubsubServer, logger.With("module", "p2p"))
+	p2pClient, err := p2p.NewClient(conf.P2P, p2pKey, genesis.ChainID, conf.blockTime, pubsubServer, logger.With("module", "p2p"))
 	if err != nil {
 		return nil, err
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -202,11 +202,11 @@ func NewNode(
 	mpIDs := nodemempool.NewMempoolIDs()
 
 	// Set p2p client and it's validators
-	p2pValidator := p2p.NewValidator(logger.With("module", "p2p_validator"), pubsubServer, settlementlc)
+	p2pValidator := p2p.NewValidator(logger.With("module", "p2p_validator"), settlementlc)
 
 	conf.P2P.GossipCacheSize = conf.BlockManagerConfig.GossipedBlocksCacheSize
 	conf.P2P.BoostrapTime = conf.BootstrapTime
-	p2pClient, err := p2p.NewClient(conf.P2P, p2pKey, genesis.ChainID, logger.With("module", "p2p"))
+	p2pClient, err := p2p.NewClient(conf.P2P, p2pKey, genesis.ChainID, pubsubServer, logger.With("module", "p2p"))
 	if err != nil {
 		return nil, err
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -206,7 +206,7 @@ func NewNode(
 
 	conf.P2P.GossipCacheSize = conf.BlockManagerConfig.GossipedBlocksCacheSize
 	conf.P2P.BoostrapTime = conf.BootstrapTime
-	p2pClient, err := p2p.NewClient(conf.P2P, p2pKey, genesis.ChainID, conf.blockTime, pubsubServer, logger.With("module", "p2p"))
+	p2pClient, err := p2p.NewClient(conf.P2P, p2pKey, genesis.ChainID, conf.BlockTime, pubsubServer, logger.With("module", "p2p"))
 	if err != nil {
 		return nil, err
 	}

--- a/p2p/client.go
+++ b/p2p/client.go
@@ -68,14 +68,15 @@ type Client struct {
 
 	localPubsubServer *tmpubsub.Server
 
-	logger types.Logger
+	blockTime time.Duration
+	logger    types.Logger
 }
 
 // NewClient creates new Client object.
 //
 // Basic checks on parameters are done, and default parameters are provided for unset-configuration
 // TODO(tzdybal): consider passing entire config, not just P2P config, to reduce number of arguments
-func NewClient(conf config.P2PConfig, privKey crypto.PrivKey, chainID string, localPubsubServer *tmpubsub.Server, logger types.Logger) (*Client, error) {
+func NewClient(conf config.P2PConfig, privKey crypto.PrivKey, chainID string, blockTime time.Duration, localPubsubServer *tmpubsub.Server, logger types.Logger) (*Client, error) {
 	if privKey == nil {
 		return nil, errNoPrivKey
 	}
@@ -88,6 +89,7 @@ func NewClient(conf config.P2PConfig, privKey crypto.PrivKey, chainID string, lo
 		chainID:           chainID,
 		logger:            logger,
 		localPubsubServer: localPubsubServer,
+		blockTime:         blockTime,
 	}, nil
 }
 
@@ -320,9 +322,9 @@ func (c *Client) tryConnect(ctx context.Context, peer peer.AddrInfo) {
 func (c *Client) setupGossiping(ctx context.Context) error {
 	pubsub.GossipSubHistoryGossip = c.conf.GossipCacheSize
 	pubsub.GossipSubHistoryLength = c.conf.GossipCacheSize
-	pubsub.GossipSubMaxIHaveMessages = c.conf.GossipCacheSize
 
-	ps, err := pubsub.NewGossipSub(ctx, c.Host)
+	//seen messages TTL is added according to the cache size  to the Gossipsub router to avoid re-requesting messages in the cache several times
+	ps, err := pubsub.NewGossipSub(ctx, c.Host, pubsub.WithSeenMessagesTTL(time.Duration(c.blockTime.Milliseconds()*int64(c.conf.GossipCacheSize))))
 	if err != nil {
 		return err
 	}

--- a/p2p/client.go
+++ b/p2p/client.go
@@ -323,8 +323,8 @@ func (c *Client) setupGossiping(ctx context.Context) error {
 	pubsub.GossipSubHistoryGossip = c.conf.GossipCacheSize
 	pubsub.GossipSubHistoryLength = c.conf.GossipCacheSize
 
-	//seen messages TTL is added according to the cache size  to the Gossipsub router to avoid re-requesting messages in the cache several times
-	ps, err := pubsub.NewGossipSub(ctx, c.Host, pubsub.WithSeenMessagesTTL(time.Duration(c.blockTime.Milliseconds()*int64(c.conf.GossipCacheSize))))
+	//seen messages TTL is added according to the cache size to the Gossipsub router to avoid re-requesting messages in the cache several times
+	ps, err := pubsub.NewGossipSub(ctx, c.Host, pubsub.WithSeenMessagesTTL(time.Duration(c.blockTime.Nanoseconds()*int64(c.conf.GossipCacheSize))))
 	if err != nil {
 		return err
 	}

--- a/p2p/client.go
+++ b/p2p/client.go
@@ -323,8 +323,8 @@ func (c *Client) setupGossiping(ctx context.Context) error {
 	pubsub.GossipSubHistoryGossip = c.conf.GossipCacheSize
 	pubsub.GossipSubHistoryLength = c.conf.GossipCacheSize
 
-	//seen messages TTL is added according to the cache size to the Gossipsub router to avoid re-requesting messages in the cache several times
-	ps, err := pubsub.NewGossipSub(ctx, c.Host, pubsub.WithSeenMessagesTTL(time.Duration(c.blockTime.Nanoseconds()*int64(c.conf.GossipCacheSize))))
+	//seen messages TTL is added according to the cache size  to the Gossipsub router to avoid re-requesting messages in the cache several times
+	ps, err := pubsub.NewGossipSub(ctx, c.Host, pubsub.WithSeenMessagesTTL(time.Duration(c.blockTime.Milliseconds()*int64(c.conf.GossipCacheSize))))
 	if err != nil {
 		return err
 	}

--- a/p2p/client.go
+++ b/p2p/client.go
@@ -327,6 +327,7 @@ func (c *Client) setupGossiping(ctx context.Context) error {
 		return err
 	}
 
+	//tx gossiper receives the tx to add to the mempool through validation process, since it is a joint process
 	c.txGossiper, err = NewGossiper(c.Host, ps, c.getTxTopic(), nil, c.logger, WithValidator(c.txValidator))
 	if err != nil {
 		return err

--- a/p2p/client.go
+++ b/p2p/client.go
@@ -68,15 +68,14 @@ type Client struct {
 
 	localPubsubServer *tmpubsub.Server
 
-	blockTime time.Duration
-	logger    types.Logger
+	logger types.Logger
 }
 
 // NewClient creates new Client object.
 //
 // Basic checks on parameters are done, and default parameters are provided for unset-configuration
 // TODO(tzdybal): consider passing entire config, not just P2P config, to reduce number of arguments
-func NewClient(conf config.P2PConfig, privKey crypto.PrivKey, chainID string, blockTime time.Duration, localPubsubServer *tmpubsub.Server, logger types.Logger) (*Client, error) {
+func NewClient(conf config.P2PConfig, privKey crypto.PrivKey, chainID string, localPubsubServer *tmpubsub.Server, logger types.Logger) (*Client, error) {
 	if privKey == nil {
 		return nil, errNoPrivKey
 	}
@@ -89,7 +88,6 @@ func NewClient(conf config.P2PConfig, privKey crypto.PrivKey, chainID string, bl
 		chainID:           chainID,
 		logger:            logger,
 		localPubsubServer: localPubsubServer,
-		blockTime:         blockTime,
 	}, nil
 }
 
@@ -322,9 +320,9 @@ func (c *Client) tryConnect(ctx context.Context, peer peer.AddrInfo) {
 func (c *Client) setupGossiping(ctx context.Context) error {
 	pubsub.GossipSubHistoryGossip = c.conf.GossipCacheSize
 	pubsub.GossipSubHistoryLength = c.conf.GossipCacheSize
+	pubsub.GossipSubMaxIHaveMessages = c.conf.GossipCacheSize
 
-	//seen messages TTL is added according to the cache size  to the Gossipsub router to avoid re-requesting messages in the cache several times
-	ps, err := pubsub.NewGossipSub(ctx, c.Host, pubsub.WithSeenMessagesTTL(time.Duration(c.blockTime.Milliseconds()*int64(c.conf.GossipCacheSize))))
+	ps, err := pubsub.NewGossipSub(ctx, c.Host)
 	if err != nil {
 		return err
 	}

--- a/p2p/validator.go
+++ b/p2p/validator.go
@@ -1,7 +1,6 @@
 package p2p
 
 import (
-	"context"
 	"errors"
 
 	"github.com/dymensionxyz/dymint/mempool"
@@ -9,7 +8,6 @@ import (
 	"github.com/dymensionxyz/dymint/settlement"
 	"github.com/dymensionxyz/dymint/types"
 	abci "github.com/tendermint/tendermint/abci/types"
-	"github.com/tendermint/tendermint/libs/pubsub"
 	corep2p "github.com/tendermint/tendermint/p2p"
 )
 
@@ -25,19 +23,17 @@ type IValidator interface {
 
 // Validator is a validator for messages gossiped in the p2p network.
 type Validator struct {
-	logger            types.Logger
-	localPubsubServer *pubsub.Server
-	slClient          settlement.LayerI
+	logger   types.Logger
+	slClient settlement.LayerI
 }
 
 var _ IValidator = (*Validator)(nil)
 
 // NewValidator creates a new Validator.
-func NewValidator(logger types.Logger, pusbsubServer *pubsub.Server, slClient settlement.LayerI) *Validator {
+func NewValidator(logger types.Logger, slClient settlement.LayerI) *Validator {
 	return &Validator{
-		logger:            logger,
-		localPubsubServer: pusbsubServer,
-		slClient:          slClient,
+		logger:   logger,
+		slClient: slClient,
 	}
 }
 
@@ -82,15 +78,15 @@ func (v *Validator) BlockValidator() GossipValidator {
 			return false
 		}
 		if err := gossipedBlock.Validate(v.slClient.GetProposer()); err != nil {
-			v.logger.Error("Invalid gossiped block", "error", err)
+			v.logger.Error("Invalid gossiped block", "height", gossipedBlock.Block.Header.Height, "error", err)
 			return false
 		}
 
-		err := v.localPubsubServer.PublishWithEvents(context.Background(), gossipedBlock, map[string][]string{EventTypeKey: {EventNewGossipedBlock}})
+		/*err := v.localPubsubServer.PublishWithEvents(context.Background(), gossipedBlock, map[string][]string{EventTypeKey: {EventNewGossipedBlock}})
 		if err != nil {
 			v.logger.Error("publishing event", "err", err)
 			return false
-		}
+		}*/
 		return true
 	}
 }

--- a/p2p/validator.go
+++ b/p2p/validator.go
@@ -78,7 +78,7 @@ func (v *Validator) BlockValidator() GossipValidator {
 			return false
 		}
 		if err := gossipedBlock.Validate(v.slClient.GetProposer()); err != nil {
-			v.logger.Error("Invalid gossiped block", "height", gossipedBlock.Block.Header.Height, "error", err)
+			v.logger.Error("Invalid gossiped block.", "height", gossipedBlock.Block.Header.Height, "error", err)
 			return false
 		}
 

--- a/p2p/validator.go
+++ b/p2p/validator.go
@@ -82,11 +82,6 @@ func (v *Validator) BlockValidator() GossipValidator {
 			return false
 		}
 
-		/*err := v.localPubsubServer.PublishWithEvents(context.Background(), gossipedBlock, map[string][]string{EventTypeKey: {EventNewGossipedBlock}})
-		if err != nil {
-			v.logger.Error("publishing event", "err", err)
-			return false
-		}*/
 		return true
 	}
 }

--- a/p2p/validator_test.go
+++ b/p2p/validator_test.go
@@ -87,7 +87,7 @@ func TestValidator_TxValidator(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			logger := log.TestingLogger()
-			validateTx := p2p.NewValidator(logger, nil, nil).TxValidator(tt.args.mp, nodemempool.NewMempoolIDs())
+			validateTx := p2p.NewValidator(logger, nil).TxValidator(tt.args.mp, nodemempool.NewMempoolIDs())
 			valid := validateTx(txMsg)
 			assert.Equalf(t, tt.want, valid, "validateTx() = %v, want %v", valid, tt.want)
 		})
@@ -179,7 +179,7 @@ func TestValidator_BlockValidator(t *testing.T) {
 			}
 
 			//Check block validity
-			validateBlock := p2p.NewValidator(logger, pubsubServer, client).BlockValidator()
+			validateBlock := p2p.NewValidator(logger, client).BlockValidator()
 			valid := validateBlock(blockMsg)
 			require.Equal(t, tt.valid, valid)
 		})

--- a/testutil/block.go
+++ b/testutil/block.go
@@ -93,11 +93,11 @@ func GetManagerWithProposerKey(conf config.BlockManagerConfig, proposerKey crypt
 	p2pClient, err := p2p.NewClient(config.P2PConfig{
 		GossipCacheSize: 50,
 		BoostrapTime:    30 * time.Second,
-	}, p2pKey, "TestChain", logger)
+	}, p2pKey, "TestChain", pubsubServer, logger)
 	if err != nil {
 		return nil, err
 	}
-	p2pValidator := p2p.NewValidator(logger, pubsubServer, settlementlc)
+	p2pValidator := p2p.NewValidator(logger, settlementlc)
 	p2pClient.SetTxValidator(p2pValidator.TxValidator(mp, mpIDs))
 	p2pClient.SetBlockValidator(p2pValidator.BlockValidator())
 

--- a/testutil/p2p.go
+++ b/testutil/p2p.go
@@ -14,6 +14,7 @@ import (
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/pubsub"
 	"go.uber.org/multierr"
 
 	"github.com/dymensionxyz/dymint/config"
@@ -100,6 +101,10 @@ func StartTestNetwork(ctx context.Context, t *testing.T, n int, conf map[int]Hos
 		seeds[src] = strings.TrimSuffix(seeds[src], ",")
 	}
 
+	pubsubServer := pubsub.NewServer()
+	err = pubsubServer.Start()
+	require.NoError(err)
+
 	clients := make([]*p2p.Client, n)
 	for i := 0; i < n; i++ {
 		client, err := p2p.NewClient(config.P2PConfig{
@@ -109,6 +114,7 @@ func StartTestNetwork(ctx context.Context, t *testing.T, n int, conf map[int]Hos
 		},
 			mnet.Hosts()[i].Peerstore().PrivKey(mnet.Hosts()[i].ID()),
 			conf[i].ChainID,
+			pubsubServer,
 			logger)
 		require.NoError(err)
 		require.NotNil(client)


### PR DESCRIPTION
# PR Standards

This PR decouples p2p gossip blocks validation from blocks reception. By doing that we avoid any interference of block store application in block propagation.

## Opening a pull request should be able to meet the following requirements

---

Close #802 

<-- Briefly describe the content of this pull request -->

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
