### PR TITLE
patch to mtsitrin/324: remove validate batch

### DIFF
--- a/block/production_test.go
+++ b/block/production_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/dymensionxyz/dymint/mempool"
 	mempoolv1 "github.com/dymensionxyz/dymint/mempool/v1"
 	"github.com/dymensionxyz/dymint/node/events"
-	"github.com/dymensionxyz/dymint/types"
 	uevent "github.com/dymensionxyz/dymint/utils/event"
 	tmcfg "github.com/tendermint/tendermint/config"
 
@@ -61,8 +60,8 @@ func TestCreateEmptyBlocksEnableDisable(t *testing.T) {
 	go manager.ProduceBlockLoop(mCtx)
 	go managerWithEmptyBlocks.ProduceBlockLoop(mCtx)
 
-	buf1 := make(chan struct{}, 100) //dummy to avoid unhealthy event
-	buf2 := make(chan struct{}, 100) //dummy to avoid unhealthy event
+	buf1 := make(chan struct{}, 100) // dummy to avoid unhealthy event
+	buf2 := make(chan struct{}, 100) // dummy to avoid unhealthy event
 	go manager.AccumulatedDataLoop(mCtx, buf1)
 	go managerWithEmptyBlocks.AccumulatedDataLoop(mCtx, buf2)
 	<-mCtx.Done()
@@ -174,44 +173,6 @@ func TestCreateEmptyBlocksNew(t *testing.T) {
 		fmt.Println("time diff:", diff, "tx len", 0)
 	}
 	assert.True(foundTx)
-}
-
-func TestInvalidBatch(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-
-	manager, err := testutil.GetManager(testutil.GetManagerConfig(), nil, nil, 1, 1, 0, nil, nil)
-	require.NoError(err)
-
-	batchSize := uint64(5)
-	syncTarget := uint64(10)
-
-	// Create cases
-	cases := []struct {
-		startHeight uint64
-		endHeight   uint64
-		shouldError bool
-	}{
-		{startHeight: syncTarget + 1, endHeight: syncTarget + batchSize, shouldError: false},
-		// batch with endHight < startHeight
-		{startHeight: syncTarget + 1, endHeight: syncTarget, shouldError: true},
-		// batch with startHeight != previousEndHeight + 1
-		{startHeight: syncTarget, endHeight: syncTarget + batchSize + batchSize, shouldError: true},
-	}
-	for _, c := range cases {
-		batch := &types.Batch{
-			StartHeight: c.startHeight,
-			EndHeight:   c.endHeight,
-		}
-
-		manager.UpdateSyncParams(syncTarget)
-		err := manager.ValidateBatch(batch)
-		if c.shouldError {
-			assert.Error(err)
-		} else {
-			assert.NoError(err)
-		}
-	}
 }
 
 // TestStopBlockProduction tests the block production stops when submitter is full

--- a/block/submit.go
+++ b/block/submit.go
@@ -131,12 +131,13 @@ func (m *Manager) HandleSubmissionTrigger() error {
 		return fmt.Errorf("submit next batch to da: %w", err)
 	}
 
-	err = m.SLClient.SubmitBatch(nextBatch, m.DAClient.GetClientType(), resultSubmitToDA)
+	syncHeight, err := m.submitNextBatchToSL(nextBatch, resultSubmitToDA)
 	if err != nil {
-		return fmt.Errorf("sl client submit batch: start height: %d: inclusive end height: %d: %w", startHeight, endHeightInclusive, err)
+		return fmt.Errorf("submit pending batch to sl: %w", err)
 	}
 
-	m.UpdateSyncParams(endHeightInclusive)
+	// Update the syncTarget to the height of the last block in the last batch as seen by this node.
+	m.UpdateSyncParams(syncHeight)
 	return nil
 }
 
@@ -151,6 +152,17 @@ func (m *Manager) submitNextBatchToDA(nextBatch *types.Batch) (*da.ResultSubmitB
 		return nil, fmt.Errorf("submit next batch to DA Layer: %s", resultSubmitToDA.Message)
 	}
 	return &resultSubmitToDA, nil
+}
+
+func (m *Manager) submitNextBatchToSL(batch *types.Batch, daResult *da.ResultSubmitBatch) (uint64, error) {
+	startHeight := batch.StartHeight
+	actualEndHeight := batch.EndHeight
+	err := m.SLClient.SubmitBatch(batch, m.DAClient.GetClientType(), daResult)
+	if err != nil {
+		return 0, fmt.Errorf("sl client submit batch: startheight: %d: actual end height: %d: %w", startHeight, actualEndHeight, err)
+	}
+
+	return actualEndHeight, nil
 }
 
 func (m *Manager) CreateNextBatchToSubmit(startHeight uint64, endHeightInclusive uint64) (*types.Batch, error) {

--- a/block/submit.go
+++ b/block/submit.go
@@ -126,10 +126,6 @@ func (m *Manager) HandleSubmissionTrigger() error {
 		return fmt.Errorf("create next batch to submit: %w", err)
 	}
 
-	if err := m.ValidateBatch(nextBatch); err != nil {
-		return fmt.Errorf("validate batch: %w", err)
-	}
-
 	resultSubmitToDA, err := m.submitNextBatchToDA(nextBatch)
 	if err != nil {
 		return fmt.Errorf("submit next batch to da: %w", err)
@@ -167,17 +163,6 @@ func (m *Manager) submitNextBatchToSL(batch *types.Batch, daResult *da.ResultSub
 	}
 
 	return actualEndHeight, nil
-}
-
-func (m *Manager) ValidateBatch(batch *types.Batch) error {
-	syncTarget := m.SyncTarget.Load()
-	if batch.StartHeight != syncTarget+1 {
-		return fmt.Errorf("batch start height != syncTarget + 1. StartHeight %d, m.SyncTarget %d", batch.StartHeight, syncTarget)
-	}
-	if batch.EndHeight < batch.StartHeight {
-		return fmt.Errorf("batch end height must be greater than start height. EndHeight %d, StartHeight %d", batch.EndHeight, batch.StartHeight)
-	}
-	return nil
 }
 
 func (m *Manager) CreateNextBatchToSubmit(startHeight uint64, endHeightInclusive uint64) (*types.Batch, error) {


### PR DESCRIPTION
The validate is unnecessary because it's valid by construction