### PR TITLE
fix(metrics): pass metrics to mempool init

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -158,7 +158,7 @@ func NewNode(
 
 	height := max(genesis.InitialHeight, info.LastBlockHeight)
 
-	mp := mempoolv1.NewTxMempool(logger, &conf.MempoolConfig, proxyApp.Mempool(), height)
+	mp := mempoolv1.NewTxMempool(logger, &conf.MempoolConfig, proxyApp.Mempool(), height, mempoolv1.WithMetrics(metrics))
 	mpIDs := nodemempool.NewMempoolIDs()
 
 	// Set p2p client and it's validators


### PR DESCRIPTION
# PR Standards

## Opening a pull request should be able to meet the following requirements

---

this change passes the received metrics provider from function arguments down to dymint mempool creation. after enabling this, mempool size metric is available on the `/metrics` endpoint. Other metrics will come in a separate PR.

```
❯ curl localhost:2112/metrics | grep dymint
# TYPE dymint_mempool_size gauge
dymint_mempool_size 0
```

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
