### PR TITLE
fix(docs): make submit loop comment more accurate re batch size

### DIFF
--- a/block/submit.go
+++ b/block/submit.go
@@ -46,11 +46,9 @@ func (m *Manager) SubmitLoop(ctx context.Context) {
 		}
 
 		/*
-				Note: since we dont explicitly coordinate changes to the accumulated size with actual batch creation
-				we don't have a guarantee that the accumulated size is the same as the actual batch size that will be made.
-				See https://github.com/dymensionxyz/dymint/issues/828
-				Until that is fixed, it's technically possibly to undercount, by having a some blocks be produced in between
-			    setting the counter to 0, and actually producing the batch.
+			Note: since we dont explicitly coordinate changes to the accumulated size with actual batch creation
+			we don't have a guarantee that the accumulated size is the same as the actual batch size that will be made.
+			But the batch creation step will also check the size is OK, so it's not a problem.
 		*/
 		m.AccumulatedBatchSize.Store(0)
 


### PR DESCRIPTION
# PR Standards

## Opening a pull request should be able to meet the following requirements

---

Close #XXX

<-- Briefly describe the content of this pull request -->

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
