### PR TITLE
fix(da): full-nodes can sync from p2p while DA light client is down or out of sync

### DIFF
--- a/block/manager.go
+++ b/block/manager.go
@@ -160,9 +160,15 @@ func (m *Manager) Start(ctx context.Context) error {
 
 	if isSequencer {
 		// TODO: populate the accumulatedSize on startup
+		err = m.syncBlockManager()
+		if err != nil {
+			return fmt.Errorf("sync block manager: %w", err)
+		}
 		go m.ProduceBlockLoop(ctx)
 		go m.SubmitLoop(ctx)
 	} else {
+		go uevent.MustSubscribe(ctx, m.Pubsub, "applyGossipedBlocksLoop", p2p.EventQueryNewNewGossipedBlock, m.onNewGossipedBlock, m.logger)
+
 		go m.RetrieveLoop(ctx)
 		go m.SyncToTargetHeightLoop(ctx)
 	}

--- a/block/manager.go
+++ b/block/manager.go
@@ -169,10 +169,6 @@ func (m *Manager) Start(ctx context.Context) error {
 		go m.ProduceBlockLoop(ctx)
 		go m.SubmitLoop(ctx)
 	} else {
-		fmt.Println("waiting")
-		<-m.DAClient.Started()
-		fmt.Println("started")
-
 		go uevent.MustSubscribe(ctx, m.Pubsub, "applyGossipedBlocksLoop", p2p.EventQueryNewNewGossipedBlock, m.onNewGossipedBlock, m.logger)
 		go m.RetrieveLoop(ctx)
 		go m.SyncToTargetHeightLoop(ctx)

--- a/block/manager.go
+++ b/block/manager.go
@@ -170,7 +170,6 @@ func (m *Manager) Start(ctx context.Context) error {
 		go m.SubmitLoop(ctx)
 	} else {
 		go uevent.MustSubscribe(ctx, m.Pubsub, "applyGossipedBlocksLoop", p2p.EventQueryNewNewGossipedBlock, m.onNewGossipedBlock, m.logger)
-
 		go m.RetrieveLoop(ctx)
 		go m.SyncToTargetHeightLoop(ctx)
 	}

--- a/block/manager.go
+++ b/block/manager.go
@@ -148,7 +148,7 @@ func (m *Manager) Start(ctx context.Context) error {
 		}
 	}
 
-	//Fullnode loop can start before syncing from DA
+	// Fullnode loop can start before syncing from DA
 	if !isSequencer {
 		go uevent.MustSubscribe(ctx, m.Pubsub, "applyGossipedBlocksLoop", p2p.EventQueryNewNewGossipedBlock, m.onNewGossipedBlock, m.logger)
 		go m.RetrieveLoop(ctx)
@@ -156,15 +156,15 @@ func (m *Manager) Start(ctx context.Context) error {
 	}
 
 	// TODO: populate the accumulatedSize on startup
-	//Wait till DA is up and running
+	// Wait till DA is up and running
 	<-m.DAClient.Started()
-	//Start syncing from DA
+	// Start syncing from DA
 	err = m.syncBlockManager()
 	if err != nil {
 		return fmt.Errorf("sync block manager: %w", err)
 	}
 
-	//Aggregator producer loop is started only when finished syncing from DA
+	// Aggregator producer loop is started only when finished syncing from DA
 	if isSequencer {
 		// TODO: populate the accumulatedSize on startup
 		//Wait till DA is up and running

--- a/block/manager.go
+++ b/block/manager.go
@@ -160,7 +160,6 @@ func (m *Manager) Start(ctx context.Context) error {
 		return fmt.Errorf("sync block manager: %w", err)
 	}
 
-	// Sequencer producer loop and full-node retrieve loop is started only when finished syncing from DA
 	if isSequencer {
 		// Sequencer must wait till DA is synced to start submitting blobs
 		<-m.DAClient.Synced()

--- a/block/manager.go
+++ b/block/manager.go
@@ -169,6 +169,10 @@ func (m *Manager) Start(ctx context.Context) error {
 		go m.ProduceBlockLoop(ctx)
 		go m.SubmitLoop(ctx)
 	} else {
+		fmt.Println("waiting")
+		<-m.DAClient.Started()
+		fmt.Println("started")
+
 		go uevent.MustSubscribe(ctx, m.Pubsub, "applyGossipedBlocksLoop", p2p.EventQueryNewNewGossipedBlock, m.onNewGossipedBlock, m.logger)
 		go m.RetrieveLoop(ctx)
 		go m.SyncToTargetHeightLoop(ctx)

--- a/block/manager.go
+++ b/block/manager.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dymensionxyz/dymint/store"
 
 	"code.cloudfoundry.org/go-diodes"
+	uevent "github.com/dymensionxyz/dymint/utils/event"
 
 	"github.com/dymensionxyz/dymint/p2p"
 	"github.com/libp2p/go-libp2p/core/crypto"
@@ -149,7 +150,9 @@ func (m *Manager) Start(ctx context.Context) error {
 
 	//Fullnode loop can start before syncing from DA
 	if !isSequencer {
-		m.startNonSequencerLoop(ctx)
+		go uevent.MustSubscribe(ctx, m.Pubsub, "applyGossipedBlocksLoop", p2p.EventQueryNewNewGossipedBlock, m.onNewGossipedBlock, m.logger)
+		go m.RetrieveLoop(ctx)
+		go m.SyncTargetLoop(ctx)
 	}
 
 	// TODO: populate the accumulatedSize on startup

--- a/block/manager.go
+++ b/block/manager.go
@@ -155,7 +155,6 @@ func (m *Manager) Start(ctx context.Context) error {
 
 	// TODO: populate the accumulatedSize on startup
 
-	// Start syncing from DA
 	err = m.syncBlockManager()
 	if err != nil {
 		return fmt.Errorf("sync block manager: %w", err)

--- a/block/manager.go
+++ b/block/manager.go
@@ -151,8 +151,6 @@ func (m *Manager) Start(ctx context.Context) error {
 	// Fullnode loop can start before syncing from DA
 	if !isSequencer {
 		go uevent.MustSubscribe(ctx, m.Pubsub, "applyGossipedBlocksLoop", p2p.EventQueryNewNewGossipedBlock, m.onNewGossipedBlock, m.logger)
-		go m.RetrieveLoop(ctx)
-		go m.SyncTargetLoop(ctx)
 	}
 
 	// TODO: populate the accumulatedSize on startup
@@ -164,7 +162,7 @@ func (m *Manager) Start(ctx context.Context) error {
 		return fmt.Errorf("sync block manager: %w", err)
 	}
 
-	// Aggregator producer loop is started only when finished syncing from DA
+	// Sequencer producer loop and full-node retrieve loop is started only when finished syncing from DA
 	if isSequencer {
 		// TODO: populate the accumulatedSize on startup
 		//Wait till DA is up and running

--- a/block/manager.go
+++ b/block/manager.go
@@ -160,6 +160,8 @@ func (m *Manager) Start(ctx context.Context) error {
 
 	if isSequencer {
 		// TODO: populate the accumulatedSize on startup
+		//Wait till DA is up and running
+		<-m.DAClient.Started()
 		err = m.syncBlockManager()
 		if err != nil {
 			return fmt.Errorf("sync block manager: %w", err)

--- a/block/retriever.go
+++ b/block/retriever.go
@@ -61,8 +61,6 @@ func (m *Manager) syncToTargetHeight(targetHeight uint64) error {
 
 	}
 
-	m.logger.Info("Synced", "store height", m.State.Height(), "target height", targetHeight)
-
 	err := m.attemptApplyCachedBlocks()
 	if err != nil {
 		m.logger.Error("Attempt apply cached blocks.", "err", err)

--- a/block/retriever.go
+++ b/block/retriever.go
@@ -37,6 +37,7 @@ func (m *Manager) RetrieveLoop(ctx context.Context) {
 // the actual blocks from the DA.
 func (m *Manager) syncToTargetHeight(targetHeight uint64) error {
 	for currH := m.State.Height(); currH < targetHeight; currH = m.State.Height() {
+		m.logger.Info("Syncing from DA", "store height", currH, "target height", targetHeight)
 
 		// It's important that we query the state index before fetching the batch, rather
 		// than e.g. keep it and increment it, because we might be concurrently applying blocks

--- a/block/retriever.go
+++ b/block/retriever.go
@@ -37,7 +37,6 @@ func (m *Manager) RetrieveLoop(ctx context.Context) {
 // the actual blocks from the DA.
 func (m *Manager) syncToTargetHeight(targetHeight uint64) error {
 	for currH := m.State.Height(); currH < targetHeight; currH = m.State.Height() {
-		m.logger.Info("Syncing from DA", "store height", currH, "target height", targetHeight)
 
 		// It's important that we query the state index before fetching the batch, rather
 		// than e.g. keep it and increment it, because we might be concurrently applying blocks
@@ -58,6 +57,7 @@ func (m *Manager) syncToTargetHeight(targetHeight uint64) error {
 		if err != nil {
 			return fmt.Errorf("process next DA batch: %w", err)
 		}
+		m.logger.Info("Synced from DA", "store height", currH, "target height", targetHeight)
 
 	}
 

--- a/da/avail/avail.go
+++ b/da/avail/avail.go
@@ -103,7 +103,7 @@ func WithBatchRetryAttempts(attempts uint) da.Option {
 // Init initializes DataAvailabilityLayerClient instance.
 func (c *DataAvailabilityLayerClient) Init(config []byte, pubsubServer *pubsub.Server, kvStore store.KVStore, logger types.Logger, options ...da.Option) error {
 	c.logger = logger
-	c.started = make(chan struct{})
+	c.started = make(chan struct{}, 1)
 
 	if len(config) > 0 {
 		err := json.Unmarshal(config, &c.config)
@@ -149,6 +149,7 @@ func (c *DataAvailabilityLayerClient) Start() error {
 // Stop stops DataAvailabilityLayerClient instance.
 func (c *DataAvailabilityLayerClient) Stop() error {
 	c.cancel()
+	close(c.started)
 	return nil
 }
 

--- a/da/avail/avail.go
+++ b/da/avail/avail.go
@@ -64,7 +64,7 @@ type DataAvailabilityLayerClient struct {
 	txInclusionTimeout time.Duration
 	batchRetryDelay    time.Duration
 	batchRetryAttempts uint
-	started            chan struct{}
+	synced             chan struct{}
 }
 
 var (
@@ -103,7 +103,7 @@ func WithBatchRetryAttempts(attempts uint) da.Option {
 // Init initializes DataAvailabilityLayerClient instance.
 func (c *DataAvailabilityLayerClient) Init(config []byte, pubsubServer *pubsub.Server, kvStore store.KVStore, logger types.Logger, options ...da.Option) error {
 	c.logger = logger
-	c.started = make(chan struct{}, 1)
+	c.synced = make(chan struct{}, 1)
 
 	if len(config) > 0 {
 		err := json.Unmarshal(config, &c.config)
@@ -142,19 +142,19 @@ func (c *DataAvailabilityLayerClient) Init(config []byte, pubsubServer *pubsub.S
 
 // Start starts DataAvailabilityLayerClient instance.
 func (c *DataAvailabilityLayerClient) Start() error {
-	c.started <- struct{}{}
+	c.synced <- struct{}{}
 	return nil
 }
 
 // Stop stops DataAvailabilityLayerClient instance.
 func (c *DataAvailabilityLayerClient) Stop() error {
 	c.cancel()
-	close(c.started)
+	close(c.synced)
 	return nil
 }
 
-func (c *DataAvailabilityLayerClient) Started() <-chan struct{} {
-	return c.started
+func (c *DataAvailabilityLayerClient) Synced() <-chan struct{} {
+	return c.synced
 }
 
 // GetClientType returns client type.

--- a/da/avail/avail.go
+++ b/da/avail/avail.go
@@ -64,6 +64,7 @@ type DataAvailabilityLayerClient struct {
 	txInclusionTimeout time.Duration
 	batchRetryDelay    time.Duration
 	batchRetryAttempts uint
+	started            bool
 }
 
 var (
@@ -102,6 +103,7 @@ func WithBatchRetryAttempts(attempts uint) da.Option {
 // Init initializes DataAvailabilityLayerClient instance.
 func (c *DataAvailabilityLayerClient) Init(config []byte, pubsubServer *pubsub.Server, kvStore store.KVStore, logger types.Logger, options ...da.Option) error {
 	c.logger = logger
+	c.started = false
 
 	if len(config) > 0 {
 		err := json.Unmarshal(config, &c.config)
@@ -135,12 +137,12 @@ func (c *DataAvailabilityLayerClient) Init(config []byte, pubsubServer *pubsub.S
 	}
 
 	c.ctx, c.cancel = context.WithCancel(context.Background())
-
 	return nil
 }
 
 // Start starts DataAvailabilityLayerClient instance.
 func (c *DataAvailabilityLayerClient) Start() error {
+	c.started = true
 	return nil
 }
 
@@ -148,6 +150,10 @@ func (c *DataAvailabilityLayerClient) Start() error {
 func (c *DataAvailabilityLayerClient) Stop() error {
 	c.cancel()
 	return nil
+}
+
+func (c *DataAvailabilityLayerClient) HasStarted() bool {
+	return c.started
 }
 
 // GetClientType returns client type.

--- a/da/avail/avail.go
+++ b/da/avail/avail.go
@@ -64,7 +64,7 @@ type DataAvailabilityLayerClient struct {
 	txInclusionTimeout time.Duration
 	batchRetryDelay    time.Duration
 	batchRetryAttempts uint
-	started            bool
+	started            chan struct{}
 }
 
 var (
@@ -103,7 +103,7 @@ func WithBatchRetryAttempts(attempts uint) da.Option {
 // Init initializes DataAvailabilityLayerClient instance.
 func (c *DataAvailabilityLayerClient) Init(config []byte, pubsubServer *pubsub.Server, kvStore store.KVStore, logger types.Logger, options ...da.Option) error {
 	c.logger = logger
-	c.started = false
+	c.started = make(chan struct{})
 
 	if len(config) > 0 {
 		err := json.Unmarshal(config, &c.config)
@@ -142,7 +142,7 @@ func (c *DataAvailabilityLayerClient) Init(config []byte, pubsubServer *pubsub.S
 
 // Start starts DataAvailabilityLayerClient instance.
 func (c *DataAvailabilityLayerClient) Start() error {
-	c.started = true
+	c.started <- struct{}{}
 	return nil
 }
 
@@ -152,7 +152,7 @@ func (c *DataAvailabilityLayerClient) Stop() error {
 	return nil
 }
 
-func (c *DataAvailabilityLayerClient) HasStarted() bool {
+func (c *DataAvailabilityLayerClient) Started() <-chan struct{} {
 	return c.started
 }
 

--- a/da/celestia/celestia.go
+++ b/da/celestia/celestia.go
@@ -168,16 +168,17 @@ func (c *DataAvailabilityLayerClient) Start() (err error) {
 			}
 		}
 
-		c.rpc = NewOpenRPC(rpc)
-		c.synced <- struct{}{}
-		c.logger.Info("celestia-node is synced")
-
 		err := retry.Do(sync,
 			retry.Attempts(0), // try forever
 			retry.Delay(10*time.Second),
 			retry.LastErrorOnly(true),
 			retry.DelayType(retry.FixedDelay),
 		)
+
+		c.logger.Info("celestia-node is synced")
+		c.rpc = NewOpenRPC(rpc)
+		c.synced <- struct{}{}
+
 		if err != nil {
 			c.logger.Error("Waiting for Celestia data availability client to sync", "err", err)
 		}

--- a/da/celestia/celestia.go
+++ b/da/celestia/celestia.go
@@ -327,20 +327,7 @@ func (c *DataAvailabilityLayerClient) retrieveBatches(daMetaData *da.DASubmitMet
 	ctx, cancel := context.WithTimeout(c.ctx, c.config.Timeout)
 	defer cancel()
 
-<<<<<<< HEAD
 	c.logger.Debug("Getting blob from DA.", "height", daMetaData.Height, "namespace", hex.EncodeToString(daMetaData.Namespace), "commitment", hex.EncodeToString(daMetaData.Commitment))
-=======
-	if c.rpc == nil {
-		return da.ResultRetrieveBatch{
-			BaseResult: da.BaseResult{
-				Code:    da.StatusError,
-				Message: "DA not available",
-				Error:   da.ErrRetrieval,
-			},
-		}
-	}
-	c.logger.Debug("Celestia DA getting blob", "height", daMetaData.Height, "namespace", hex.EncodeToString(daMetaData.Namespace), "commitment", hex.EncodeToString(daMetaData.Commitment))
->>>>>>> 0ffc865 (retry if celestia fails to start + start check)
 	var batches []*types.Batch
 	blob, err := c.rpc.Get(ctx, daMetaData.Height, daMetaData.Namespace, daMetaData.Commitment)
 	if err != nil {

--- a/da/celestia/celestia.go
+++ b/da/celestia/celestia.go
@@ -165,7 +165,6 @@ func (c *DataAvailabilityLayerClient) Start() (err error) {
 					}
 				}
 			}
-
 		}
 
 		c.rpc = NewOpenRPC(rpc)

--- a/da/celestia/celestia.go
+++ b/da/celestia/celestia.go
@@ -176,6 +176,7 @@ func (c *DataAvailabilityLayerClient) Start() (err error) {
 			}
 
 			c.rpc = NewOpenRPC(rpc)
+			c.started <- struct{}{}
 
 			c.logger.Info("celestia-node is synced", "height", state.ToHeight)
 
@@ -186,7 +187,6 @@ func (c *DataAvailabilityLayerClient) Start() (err error) {
 		retry.LastErrorOnly(true),
 		retry.DelayType(retry.FixedDelay),
 	)
-	c.started <- struct{}{}
 	return nil
 
 }

--- a/da/celestia/celestia.go
+++ b/da/celestia/celestia.go
@@ -152,12 +152,13 @@ func (c *DataAvailabilityLayerClient) Start() (err error) {
 				select {
 				case err := <-done:
 					if err != nil {
-						c.logger.Error("Failed to start Celestia DA.", "Error", err)
+						c.logger.Error("Failed to sync Celestia DA.", "Error", err)
 					}
 					return err
 				case <-ticker.C:
 					state, err := rpc.Header.SyncState(c.ctx)
 					if err != nil {
+						c.logger.Error("Failed to sync Celestia DA.", "Error", err)
 						return err
 					}
 					if !state.Finished() {

--- a/da/celestia/celestia.go
+++ b/da/celestia/celestia.go
@@ -139,53 +139,58 @@ func (c *DataAvailabilityLayerClient) Start() (err error) {
 		return err
 	}
 
-	go retry.Do(
-		func() error {
-			state, err := rpc.Header.SyncState(c.ctx)
-			if err != nil {
-				c.logger.Error("Failed to start Celestia DA.", "Error", err)
-				return err
-			}
+	go func() {
+		err := retry.Do(
+			func() error {
+				state, err := rpc.Header.SyncState(c.ctx)
+				if err != nil {
+					c.logger.Error("Failed to start Celestia DA.", "Error", err)
+					return err
+				}
 
-			if !state.Finished() {
-				c.logger.Info("waiting for celestia-node to finish syncing", "height", state.Height, "target", state.ToHeight)
+				if !state.Finished() {
+					c.logger.Info("waiting for celestia-node to finish syncing", "height", state.Height, "target", state.ToHeight)
 
-				done := make(chan error, 1)
-				go func() {
-					done <- rpc.Header.SyncWait(c.ctx)
-				}()
+					done := make(chan error, 1)
+					go func() {
+						done <- rpc.Header.SyncWait(c.ctx)
+					}()
 
-				ticker := time.NewTicker(1 * time.Minute)
-				defer ticker.Stop()
+					ticker := time.NewTicker(1 * time.Minute)
+					defer ticker.Stop()
 
-				for {
-					select {
-					case err := <-done:
-						if err != nil {
-							return err
+					for {
+						select {
+						case err := <-done:
+							if err != nil {
+								return err
+							}
+							return nil
+						case <-ticker.C:
+							state, err := rpc.Header.SyncState(c.ctx)
+							if err != nil {
+								return err
+							}
+							c.logger.Info("celestia-node still syncing", "height", state.Height, "target", state.ToHeight)
 						}
-						return nil
-					case <-ticker.C:
-						state, err := rpc.Header.SyncState(c.ctx)
-						if err != nil {
-							return err
-						}
-						c.logger.Info("celestia-node still syncing", "height", state.Height, "target", state.ToHeight)
 					}
 				}
-			}
 
-			c.rpc = NewOpenRPC(rpc)
-			c.started <- struct{}{}
-			c.logger.Info("celestia-node is synced", "height", state.ToHeight)
+				c.rpc = NewOpenRPC(rpc)
+				c.started <- struct{}{}
+				c.logger.Info("celestia-node is synced", "height", state.ToHeight)
 
-			return nil
-		},
-		retry.Attempts(0), // try forever
-		retry.Delay(10*time.Second),
-		retry.LastErrorOnly(true),
-		retry.DelayType(retry.FixedDelay),
-	)
+				return nil
+			},
+			retry.Attempts(0), // try forever
+			retry.Delay(10*time.Second),
+			retry.LastErrorOnly(true),
+			retry.DelayType(retry.FixedDelay),
+		)
+		if err != nil {
+			c.logger.Error("Error when waiting for Celestia data availability client to sync", "err", err)
+		}
+	}()
 	return nil
 
 }

--- a/da/celestia/celestia.go
+++ b/da/celestia/celestia.go
@@ -76,7 +76,7 @@ func WithSubmitBackoff(c uretry.BackoffConfig) da.Option {
 // Init initializes DataAvailabilityLayerClient instance.
 func (c *DataAvailabilityLayerClient) Init(config []byte, pubsubServer *pubsub.Server, kvStore store.KVStore, logger types.Logger, options ...da.Option) error {
 	c.logger = logger
-	c.started = make(chan struct{})
+	c.started = make(chan struct{}, 1)
 	var err error
 	c.config, err = createConfig(config)
 	if err != nil {
@@ -177,7 +177,6 @@ func (c *DataAvailabilityLayerClient) Start() (err error) {
 
 			c.rpc = NewOpenRPC(rpc)
 			c.started <- struct{}{}
-
 			c.logger.Info("celestia-node is synced", "height", state.ToHeight)
 
 			return nil
@@ -199,6 +198,7 @@ func (c *DataAvailabilityLayerClient) Stop() error {
 		return err
 	}
 	c.cancel()
+	close(c.started)
 	return nil
 }
 

--- a/da/da.go
+++ b/da/da.go
@@ -215,7 +215,7 @@ type DataAvailabilityLayerClient interface {
 	// CheckBatchAvailability checks the availability of the blob submitted getting proofs and validating them
 	CheckBatchAvailability(daMetaData *DASubmitMetaData) ResultCheckBatch
 
-	HasStarted() bool
+	Started() <-chan struct{}
 }
 
 // BatchRetriever is additional interface that can be implemented by Data Availability Layer Client that is able to retrieve

--- a/da/da.go
+++ b/da/da.go
@@ -214,6 +214,8 @@ type DataAvailabilityLayerClient interface {
 
 	// CheckBatchAvailability checks the availability of the blob submitted getting proofs and validating them
 	CheckBatchAvailability(daMetaData *DASubmitMetaData) ResultCheckBatch
+
+	HasStarted() bool
 }
 
 // BatchRetriever is additional interface that can be implemented by Data Availability Layer Client that is able to retrieve

--- a/da/da.go
+++ b/da/da.go
@@ -215,7 +215,7 @@ type DataAvailabilityLayerClient interface {
 	// CheckBatchAvailability checks the availability of the blob submitted getting proofs and validating them
 	CheckBatchAvailability(daMetaData *DASubmitMetaData) ResultCheckBatch
 
-	Started() <-chan struct{}
+	Synced() <-chan struct{}
 }
 
 // BatchRetriever is additional interface that can be implemented by Data Availability Layer Client that is able to retrieve

--- a/da/grpc/grpc.go
+++ b/da/grpc/grpc.go
@@ -19,10 +19,10 @@ import (
 type DataAvailabilityLayerClient struct {
 	config Config
 
-	conn   *grpc.ClientConn
-	client dalc.DALCServiceClient
-
-	logger types.Logger
+	conn    *grpc.ClientConn
+	client  dalc.DALCServiceClient
+	started bool
+	logger  types.Logger
 }
 
 // Config contains configuration options for DataAvailabilityLayerClient.
@@ -50,6 +50,7 @@ func (d *DataAvailabilityLayerClient) Init(config []byte, _ *pubsub.Server, _ st
 		d.config = DefaultConfig
 		return nil
 	}
+	d.started = false
 	return json.Unmarshal(config, &d.config)
 }
 
@@ -66,7 +67,7 @@ func (d *DataAvailabilityLayerClient) Start() error {
 	}
 
 	d.client = dalc.NewDALCServiceClient(d.conn)
-
+	d.started = true
 	return nil
 }
 
@@ -74,6 +75,10 @@ func (d *DataAvailabilityLayerClient) Start() error {
 func (d *DataAvailabilityLayerClient) Stop() error {
 	d.logger.Info("stopoing GRPC DALC")
 	return d.conn.Close()
+}
+
+func (d *DataAvailabilityLayerClient) HasStarted() bool {
+	return d.started
 }
 
 // GetClientType returns client type.

--- a/da/grpc/grpc.go
+++ b/da/grpc/grpc.go
@@ -50,13 +50,15 @@ func (d *DataAvailabilityLayerClient) Init(config []byte, _ *pubsub.Server, _ st
 		d.config = DefaultConfig
 		return nil
 	}
-	d.started = make(chan struct{})
+	d.started = make(chan struct{}, 1)
 	return json.Unmarshal(config, &d.config)
 }
 
 // Start creates connection to gRPC server and instantiates gRPC client.
 func (d *DataAvailabilityLayerClient) Start() error {
 	d.logger.Info("starting GRPC DALC", "host", d.config.Host, "port", d.config.Port)
+	d.started <- struct{}{}
+
 	var err error
 	var opts []grpc.DialOption
 	// TODO(tzdybal): add more options
@@ -67,7 +69,6 @@ func (d *DataAvailabilityLayerClient) Start() error {
 	}
 
 	d.client = dalc.NewDALCServiceClient(d.conn)
-	d.started <- struct{}{}
 	return nil
 }
 

--- a/da/local/local.go
+++ b/da/local/local.go
@@ -20,7 +20,7 @@ type DataAvailabilityLayerClient struct {
 	dalcKV   store.KVStore
 	daHeight atomic.Uint64
 	config   config
-	started  bool
+	started  chan struct{}
 }
 
 const defaultBlockTime = 3 * time.Second
@@ -48,7 +48,7 @@ func (m *DataAvailabilityLayerClient) Init(config []byte, _ *pubsub.Server, dalc
 	} else {
 		m.config.BlockTime = defaultBlockTime
 	}
-	m.started = false
+	m.started = make(chan struct{})
 	return nil
 }
 
@@ -61,7 +61,7 @@ func (m *DataAvailabilityLayerClient) Start() error {
 			m.updateDAHeight()
 		}
 	}()
-	m.started = true
+	m.started <- struct{}{}
 	return nil
 }
 
@@ -71,7 +71,8 @@ func (m *DataAvailabilityLayerClient) Stop() error {
 	return nil
 }
 
-func (m *DataAvailabilityLayerClient) HasStarted() bool {
+// Started returns channel for on start event
+func (m *DataAvailabilityLayerClient) Started() <-chan struct{} {
 	return m.started
 }
 

--- a/da/local/local.go
+++ b/da/local/local.go
@@ -20,6 +20,7 @@ type DataAvailabilityLayerClient struct {
 	dalcKV   store.KVStore
 	daHeight atomic.Uint64
 	config   config
+	started  bool
 }
 
 const defaultBlockTime = 3 * time.Second
@@ -47,6 +48,7 @@ func (m *DataAvailabilityLayerClient) Init(config []byte, _ *pubsub.Server, dalc
 	} else {
 		m.config.BlockTime = defaultBlockTime
 	}
+	m.started = false
 	return nil
 }
 
@@ -59,6 +61,7 @@ func (m *DataAvailabilityLayerClient) Start() error {
 			m.updateDAHeight()
 		}
 	}()
+	m.started = true
 	return nil
 }
 
@@ -66,6 +69,10 @@ func (m *DataAvailabilityLayerClient) Start() error {
 func (m *DataAvailabilityLayerClient) Stop() error {
 	m.logger.Debug("Mock Data Availability Layer Client stopped")
 	return nil
+}
+
+func (m *DataAvailabilityLayerClient) HasStarted() bool {
+	return m.started
 }
 
 // GetClientType returns client type.

--- a/da/local/local.go
+++ b/da/local/local.go
@@ -48,26 +48,28 @@ func (m *DataAvailabilityLayerClient) Init(config []byte, _ *pubsub.Server, dalc
 	} else {
 		m.config.BlockTime = defaultBlockTime
 	}
-	m.started = make(chan struct{})
+	m.started = make(chan struct{}, 1)
 	return nil
 }
 
 // Start implements DataAvailabilityLayerClient interface.
 func (m *DataAvailabilityLayerClient) Start() error {
 	m.logger.Debug("Mock Data Availability Layer Client starting")
+	m.started <- struct{}{}
 	go func() {
 		for {
 			time.Sleep(m.config.BlockTime)
 			m.updateDAHeight()
 		}
 	}()
-	m.started <- struct{}{}
+
 	return nil
 }
 
 // Stop implements DataAvailabilityLayerClient interface.
 func (m *DataAvailabilityLayerClient) Stop() error {
 	m.logger.Debug("Mock Data Availability Layer Client stopped")
+	close(m.started)
 	return nil
 }
 

--- a/da/local/local.go
+++ b/da/local/local.go
@@ -20,7 +20,7 @@ type DataAvailabilityLayerClient struct {
 	dalcKV   store.KVStore
 	daHeight atomic.Uint64
 	config   config
-	started  chan struct{}
+	synced   chan struct{}
 }
 
 const defaultBlockTime = 3 * time.Second
@@ -48,14 +48,14 @@ func (m *DataAvailabilityLayerClient) Init(config []byte, _ *pubsub.Server, dalc
 	} else {
 		m.config.BlockTime = defaultBlockTime
 	}
-	m.started = make(chan struct{}, 1)
+	m.synced = make(chan struct{}, 1)
 	return nil
 }
 
 // Start implements DataAvailabilityLayerClient interface.
 func (m *DataAvailabilityLayerClient) Start() error {
 	m.logger.Debug("Mock Data Availability Layer Client starting")
-	m.started <- struct{}{}
+	m.synced <- struct{}{}
 	go func() {
 		for {
 			time.Sleep(m.config.BlockTime)
@@ -69,13 +69,13 @@ func (m *DataAvailabilityLayerClient) Start() error {
 // Stop implements DataAvailabilityLayerClient interface.
 func (m *DataAvailabilityLayerClient) Stop() error {
 	m.logger.Debug("Mock Data Availability Layer Client stopped")
-	close(m.started)
+	close(m.synced)
 	return nil
 }
 
-// Started returns channel for on start event
-func (m *DataAvailabilityLayerClient) Started() <-chan struct{} {
-	return m.started
+// Synced returns channel for on start event
+func (m *DataAvailabilityLayerClient) Synced() <-chan struct{} {
+	return m.synced
 }
 
 // GetClientType returns client type.


### PR DESCRIPTION
# PR Standards

The main objective of this PR is the startup process for Celestia DA for full-nodes. With the modifications, full nodes will not wait for a DA to be in sync (or up) and it will do the syncing process in the background, while the full-node can start receiving and caching gossiped blocks from P2P. It also solves  a nil pointer error that was happening when DA light finished syncing and a full-node was started when was not still in sync. Without the modifications of this PR, a node could start receiving gossiped blocks, but everything received while DA was syncing was disregarded because the block manager was not started, waiting for the celestia light node to finish the syncing process.

## Opening a pull request should be able to meet the following requirements

---

Close #856 , #799 , https://github.com/dymensionxyz/dymint/issues/770

<-- Briefly describe the content of this pull request -->

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
