### PR TITLE
feat(ci): new changelog workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,42 +12,66 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: '18'
 
-      - name: Generate Changelog Update
+      - name: Configure Git
         run: |
-          npm install -g conventional-changelog-cli
-          conventional-changelog -p angular -i CHANGELOG.md -s
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
 
-      - name: Check if "auto-changelog-update" branch exists and update if needed
+      - name: Check if "auto-changelog-update-do-not-create-manually" branch exists
         id: check_branch
         run: |
-          git fetch origin auto-changelog-update:auto-changelog-update --no-tags
-          if git rev-parse --verify --quiet auto-changelog-update; then
-            echo "::set-output name=branch_exists::true"
-            git checkout auto-changelog-update
-            git merge main --no-edit
+          if [ -n "$(git ls-remote --heads origin auto-changelog-update-do-not-create-manually)" ]; then
+            git fetch origin auto-changelog-update-do-not-create-manually
+            echo "branch_exists=true" >> $GITHUB_ENV
           else
-            echo "::set-output name=branch_exists::false"
-            git checkout -b auto-changelog-update
+            echo "branch_exists=false" >> $GITHUB_ENV
           fi
 
-      - name: Create or Update Pull Request
+      - name: Generate Changelog Update and update if branch exists
+        run: |
+          npm install -g conventional-changelog-cli
+          if [ "$branch_exists" == "true" ]; then
+            git checkout auto-changelog-update-do-not-create-manually
+            git merge main --strategy-option theirs --allow-unrelated-histories --no-edit
+            conventional-changelog -p angular -i CHANGELOG.md -s -r 0 --append
+            git add CHANGELOG.md
+            git commit -m "Update CHANGELOG.md [skip ci]"
+            git push origin auto-changelog-update-do-not-create-manually
+            exit 0
+          else
+            git checkout main
+            git checkout -b auto-changelog-update-do-not-create-manually
+            git push origin auto-changelog-update-do-not-create-manually
+            conventional-changelog -p angular -i CHANGELOG.md -s -r 0 --append
+          fi
+
+      - name: Create Pull Request
+        if: env.branch_exists == 'false'
         id: cpr
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v6
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Update CHANGELOG.md [skip ci]"
-          title: "Automated Changelog Update"
+          title: "Chore(changelog): Automated Changelog Update [skip ci]"
           body: "Update the CHANGELOG.md with recent pushes to branch main."
-          branch: "auto-changelog-update"  # Static branch name
+          base: "main"
+          branch: "auto-changelog-update-do-not-create-manually"
           delete-branch: true
-          branch-suffix: none
-      - name: Check if PR needs to be updated
+
+      - name: Check outputs
+        if: env.branch_exists == 'false'
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
+
+      - name: Log if PR updated
         if: steps.cpr.outputs.pull-request-operation == 'updated'
         run: |
           echo "Changelog PR updated due to new commit to main."


### PR DESCRIPTION
# PR Standards

## Opening a pull request should be able to meet the following requirements

---

This PR add auto changelog workflow as the following:

When new commit pushed/PR merged to main branch then

Check if a changelog PR already opened:

- (Yes) merge from main branch (with ort strag) if needed, then new changelog entry will be append to changelog.md and update to already open PR then exit.
- (No) checkout from main branch, generate changelog entry and create PR.

Branch should delete automatically on next ci run, or you can delete it manully.

**NOTE**

Do not create branch "auto-changelog-update-do-not-create-manually" manually.

For Author:

- [x]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [x]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
