### PR TITLE
Feat(ci): Add stale bot

### DIFF
--- a/.github/workflows/label-internal-pr.yml
+++ b/.github/workflows/label-internal-pr.yml
@@ -1,0 +1,28 @@
+name: "Label PRs from Dymension internal"
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  label-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+
+      - name: Get Pull Request Author Organization
+        id: pr
+        run: |
+          pr_author=$(jq -r .pull_request.user.login "$GITHUB_EVENT_PATH")
+          org=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/users/$pr_author/orgs" | jq -r '.[].login')
+          echo "pr_author=${pr_author}" >> $GITHUB_ENV
+          echo "org=${org}" >> $GITHUB_ENV
+
+      - name: Add Label if Author is from Organization
+        if: contains(env.org, 'Dymensionxyz')
+        run: |
+          curl -s -X POST -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels \
+          -d '{"labels":["dym-internal"]}'
+

--- a/.github/workflows/label-internal-pr.yml
+++ b/.github/workflows/label-internal-pr.yml
@@ -10,19 +10,29 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v3
 
-      - name: Get Pull Request Author Organization
+      - name: Get Pull Request Author and Check Membership
         id: pr
         run: |
           pr_author=$(jq -r .pull_request.user.login "$GITHUB_EVENT_PATH")
-          org=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/users/$pr_author/orgs" | jq -r '.[].login')
-          echo "pr_author=${pr_author}" >> $GITHUB_ENV
-          echo "org=${org}" >> $GITHUB_ENV
+          echo "PR Author: ${pr_author}"
+          org="dymensionxyz"
+          membership_response=$(curl -s -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/orgs/${org}/public_members/${pr_author})
+          echo "Membership response: ${membership_response}"
+          if [ -z "$membership_response" ]; then
+            is_member=false
+          else
+            is_member=true
+          fi
+          echo "is_member=${is_member}" >> $GITHUB_ENV
 
       - name: Add Label if Author is from Organization
-        if: contains(env.org, 'Dymensionxyz')
+        if: env.is_member == 'true'
         run: |
           curl -s -X POST -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
           -H "Accept: application/vnd.github.v3+json" \
           https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels \
           -d '{"labels":["dym-internal"]}'
-

--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -1,0 +1,27 @@
+name: "Close stale pull requests"
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    permissions:
+      issues: write # for actions/stale to close stale issues
+      pull-requests: write # for actions/stale to close stale PRs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it
+            has not had any recent activity. It will be closed if no further
+            activity occurs. Thank you!
+          days-before-stale: -1
+          days-before-close: -1
+          days-before-pr-stale: 8
+          days-before-pr-close: 3
+          exempt-pr-labels: "security, proposal, blocked"

--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -24,4 +24,4 @@ jobs:
           days-before-close: -1
           days-before-pr-stale: 8
           days-before-pr-close: 3
-          exempt-pr-labels: "security, proposal, blocked"
+          exempt-pr-labels: "security, proposal, blocked, dym-internal"


### PR DESCRIPTION
# PR Standards

This PR add stale bot CI to automatically mark PR as stale after 8 days and close PR after 11 days without activity. Except PR with "security, proposal, blocked, dym-internal" labels.

Another CI workflow will check opened, synchronize PR and mark those PR as dym-internal to exclude it from being mark and close.

---

For Author:

- [x]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
