### PR TITLE
fix: remove unnecessary `:` in the json response

### DIFF
--- a/rpc/middleware/middleware_test.go
+++ b/rpc/middleware/middleware_test.go
@@ -76,12 +76,12 @@ func TestStatusMiddleware(t *testing.T) {
 		{
 			healthy:         nil,
 			expectedStatus:  http.StatusOK,
-			expectedMessage: "{\"jsonrpc\":\"2.0\",\"result\":{\"isHealthy\":true,:\"error\":\"\"},\"id\":-1}",
+			expectedMessage: "{\"jsonrpc\":\"2.0\",\"result\":{\"isHealthy\":true,\"error\":\"\"},\"id\":-1}",
 		},
 		{
 			healthy:         errors.New("node unhealthy"),
 			expectedStatus:  http.StatusOK,
-			expectedMessage: "{\"jsonrpc\":\"2.0\",\"result\":{\"isHealthy\":false,:\"error\":\"node unhealthy\"},\"id\":-1}",
+			expectedMessage: "{\"jsonrpc\":\"2.0\",\"result\":{\"isHealthy\":false,\"error\":\"node unhealthy\"},\"id\":-1}",
 		},
 	}
 

--- a/rpc/middleware/status.go
+++ b/rpc/middleware/status.go
@@ -24,7 +24,7 @@ func (s Status) Handler(logger log.Logger) HandlerFunc {
 				if err != nil {
 					errS = err.Error()
 				}
-				json := `{"jsonrpc":"2.0","result":{"isHealthy":` + strconv.FormatBool(isHealthy) + `,:"error":"` + errS + `"},"id":-1}`
+				json := `{"jsonrpc":"2.0","result":{"isHealthy":` + strconv.FormatBool(isHealthy) + `,"error":"` + errS + `"},"id":-1}`
 				_, err = w.Write([]byte(json))
 				if err != nil {
 					return


### PR DESCRIPTION
# PR Standards

## Opening a pull request should be able to meet the following requirements

---

Close #XXX

<-- Briefly describe the content of this pull request -->

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
