### PR TITLE
fix(code standards): use gerr err not found

### DIFF
--- a/block/produce.go
+++ b/block/produce.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/dymensionxyz/dymint/gerr"
+
 	"github.com/dymensionxyz/dymint/store"
 
 	"github.com/dymensionxyz/dymint/types"
@@ -123,7 +125,7 @@ func (m *Manager) produceBlock(allowEmpty bool) (*types.Block, *types.Commit, er
 			return nil, nil, fmt.Errorf("load commit after load block: height: %d: %w: %w", newHeight, err, ErrNonRecoverable)
 		}
 		m.logger.Info("Using pending block.", "height", newHeight)
-	} else if !errors.Is(err, store.ErrKeyNotFound) {
+	} else if !errors.Is(err, gerr.ErrNotFound) {
 		return nil, nil, fmt.Errorf("load block: height: %d: %w: %w", newHeight, err, ErrNonRecoverable)
 	} else {
 		block = m.Executor.CreateBlock(newHeight, lastCommit, lastHeaderHash, m.State, m.Conf.BlockBatchMaxSizeBytes)

--- a/indexers/blockindexer/kv/kv.go
+++ b/indexers/blockindexer/kv/kv.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/dymensionxyz/dymint/gerr"
+
 	"github.com/google/orderedcode"
 
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -43,7 +45,7 @@ func (idx *BlockerIndexer) Has(height int64) (bool, error) {
 	}
 
 	_, err = idx.store.Get(key)
-	if errors.Is(err, store.ErrKeyNotFound) {
+	if errors.Is(err, gerr.ErrNotFound) {
 		return false, nil
 	}
 	return err == nil, err

--- a/store/badger.go
+++ b/store/badger.go
@@ -3,6 +3,8 @@ package store
 import (
 	"errors"
 
+	"github.com/dymensionxyz/dymint/gerr"
+
 	"github.com/dgraph-io/badger/v3"
 )
 
@@ -10,9 +12,6 @@ var (
 	_ KVStore = &BadgerKV{}
 	_ Batch   = &BadgerBatch{}
 )
-
-// ErrKeyNotFound is returned if key is not found in KVStore.
-var ErrKeyNotFound = errors.New("key not found")
 
 // BadgerKV is a implementation of KVStore using Badger v3.
 type BadgerKV struct {
@@ -25,7 +24,7 @@ func (b *BadgerKV) Get(key []byte) ([]byte, error) {
 	defer txn.Discard()
 	item, err := txn.Get(key)
 	if errors.Is(err, badger.ErrKeyNotFound) {
-		return nil, ErrKeyNotFound
+		return nil, gerr.ErrNotFound
 	}
 	if err != nil {
 		return nil, err

--- a/store/badger_test.go
+++ b/store/badger_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/dymensionxyz/dymint/gerr"
+
 	"github.com/dgraph-io/badger/v3"
 )
 
@@ -16,7 +18,7 @@ func TestGetErrors(t *testing.T) {
 		err  error
 	}{
 		{"empty key", []byte{}, badger.ErrEmptyKey},
-		{"not found key", []byte("missing key"), ErrKeyNotFound},
+		{"not found key", []byte("missing key"), gerr.ErrNotFound},
 	}
 
 	for _, tt := range tc {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/dymensionxyz/dymint/gerr"
+
 	abcitypes "github.com/tendermint/tendermint/abci/types"
 	tmstate "github.com/tendermint/tendermint/proto/tendermint/state"
 
@@ -186,7 +188,7 @@ func TestBatch(t *testing.T) {
 	assert.NoError(err)
 
 	resp, err := s.LoadBlockResponses(1)
-	assert.EqualError(err, "retrieve block results from height 1: key not found") // TODO: use errors.Is
+	assert.Error(err, gerr.ErrNotFound)
 	assert.Nil(resp)
 
 	err = batch.Commit()


### PR DESCRIPTION
uses a standard err definition instead of a bespoke one