### PR TITLE
fix(block manage): reducing batch overhead size when reaping Txs from mempool

### DIFF
--- a/block/executor.go
+++ b/block/executor.go
@@ -96,11 +96,11 @@ func (e *Executor) InitChain(genesis *tmtypes.GenesisDoc, validators []*tmtypes.
 }
 
 // CreateBlock reaps transactions from mempool and builds a block.
-func (e *Executor) CreateBlock(height uint64, lastCommit *types.Commit, lastHeaderHash [32]byte, state *types.State, maxBytes uint64) *types.Block {
+func (e *Executor) CreateBlock(height uint64, lastCommit *types.Commit, lastHeaderHash [32]byte, state *types.State, maxBlockDataSizeBytes uint64) *types.Block {
 	if state.ConsensusParams.Block.MaxBytes > 0 {
-		maxBytes = min(maxBytes, uint64(state.ConsensusParams.Block.MaxBytes))
+		maxBlockDataSizeBytes = min(maxBlockDataSizeBytes, uint64(state.ConsensusParams.Block.MaxBytes))
 	}
-	mempoolTxs := e.mempool.ReapMaxBytesMaxGas(int64(maxBytes), state.ConsensusParams.Block.MaxGas)
+	mempoolTxs := e.mempool.ReapMaxBytesMaxGas(int64(maxBlockDataSizeBytes), state.ConsensusParams.Block.MaxGas)
 
 	block := &types.Block{
 		Header: types.Header{

--- a/block/produce.go
+++ b/block/produce.go
@@ -128,7 +128,7 @@ func (m *Manager) produceBlock(allowEmpty bool) (*types.Block, *types.Commit, er
 	} else if !errors.Is(err, gerr.ErrNotFound) {
 		return nil, nil, fmt.Errorf("load block: height: %d: %w: %w", newHeight, err, ErrNonRecoverable)
 	} else {
-		maxBlockSizeByBatchSize := m.Conf.BlockBatchMaxSizeBytes - uint64(BatchOverhead)
+		maxBlockSizeByBatchSize := uint64(float64(m.Conf.BlockBatchMaxSizeBytes) * types.MaxBlockSizeAdjustment)
 		block = m.Executor.CreateBlock(newHeight, lastCommit, lastHeaderHash, m.State, maxBlockSizeByBatchSize)
 		if !allowEmpty && len(block.Data.Txs) == 0 {
 			return nil, nil, fmt.Errorf("%w: %w", types.ErrSkippedEmptyBlock, ErrRecoverable)

--- a/block/produce.go
+++ b/block/produce.go
@@ -128,8 +128,9 @@ func (m *Manager) produceBlock(allowEmpty bool) (*types.Block, *types.Commit, er
 	} else if !errors.Is(err, gerr.ErrNotFound) {
 		return nil, nil, fmt.Errorf("load block: height: %d: %w: %w", newHeight, err, ErrNonRecoverable)
 	} else {
-		maxBlockSizeByBatchSize := uint64(float64(m.Conf.BlockBatchMaxSizeBytes) * types.MaxBlockSizeAdjustment)
-		block = m.Executor.CreateBlock(newHeight, lastCommit, lastHeaderHash, m.State, maxBlockSizeByBatchSize)
+		// limit to the max block data, so we don't create a block that is too big to fit in a batch
+		maxBlockDataSize := uint64(float64(m.Conf.BlockBatchMaxSizeBytes) * types.MaxBlockSizeAdjustment)
+		block = m.Executor.CreateBlock(newHeight, lastCommit, lastHeaderHash, m.State, maxBlockDataSize)
 		if !allowEmpty && len(block.Data.Txs) == 0 {
 			return nil, nil, fmt.Errorf("%w: %w", types.ErrSkippedEmptyBlock, ErrRecoverable)
 		}

--- a/block/produce.go
+++ b/block/produce.go
@@ -128,7 +128,8 @@ func (m *Manager) produceBlock(allowEmpty bool) (*types.Block, *types.Commit, er
 	} else if !errors.Is(err, gerr.ErrNotFound) {
 		return nil, nil, fmt.Errorf("load block: height: %d: %w: %w", newHeight, err, ErrNonRecoverable)
 	} else {
-		block = m.Executor.CreateBlock(newHeight, lastCommit, lastHeaderHash, m.State, m.Conf.BlockBatchMaxSizeBytes)
+		maxBlockSizeByBatchSize := m.Conf.BlockBatchMaxSizeBytes - uint64(BatchOverhead)
+		block = m.Executor.CreateBlock(newHeight, lastCommit, lastHeaderHash, m.State, maxBlockSizeByBatchSize)
 		if !allowEmpty && len(block.Data.Txs) == 0 {
 			return nil, nil, fmt.Errorf("%w: %w", types.ErrSkippedEmptyBlock, ErrRecoverable)
 		}

--- a/block/types.go
+++ b/block/types.go
@@ -9,10 +9,6 @@ import (
 
 // TODO: move to types package
 
-const (
-	BatchOverhead = 700 // 500 block overhead + 117 for commit + 10 for batch overhead + safety margin
-)
-
 type blockSource string
 
 const (

--- a/block/types.go
+++ b/block/types.go
@@ -8,6 +8,11 @@ import (
 )
 
 // TODO: move to types package
+
+const (
+	BatchOverhead = 700 // 500 block overhead + 117 for commit + 10 for batch overhead + safety margin
+)
+
 type blockSource string
 
 const (

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -193,7 +193,7 @@ func fullNodeConfig() config.NodeConfig {
 			BatchSubmitMaxTime:     20 * time.Second,
 			MaxSupportedBatchSkew:  10,
 			NamespaceID:            "test",
-			BlockBatchMaxSizeBytes: 1,
+			BlockBatchMaxSizeBytes: 10000,
 		},
 		DALayer:         "celestia",
 		DAConfig:        "da-config",

--- a/testutil/types.go
+++ b/testutil/types.go
@@ -38,11 +38,11 @@ func createRandomHashes() [][32]byte {
 
 func GetRandomTx() types.Tx {
 	n, _ := rand.Int(rand.Reader, big.NewInt(100))
-	size := int(n.Int64()) + 100
+	size := uint64(n.Int64()) + 100
 	return types.Tx(GetRandomBytes(size))
 }
 
-func GetRandomBytes(n int) []byte {
+func GetRandomBytes(n uint64) []byte {
 	data := make([]byte, n)
 	_, _ = rand.Read(data)
 	return data

--- a/types/batch.go
+++ b/types/batch.go
@@ -1,5 +1,9 @@
 package types
 
+const (
+	MaxBlockSizeAdjustment = 0.9 // have a safety margin of 10% in regard of MaxBlockBatchSizeBytes
+)
+
 // Batch defines a struct for block aggregation for support of batching.
 // TODO: maybe change to BlockBatch
 type Batch struct {


### PR DESCRIPTION
# PR Standards

## Opening a pull request should be able to meet the following requirements

--

PR naming convention: https://hackmd.io/@nZpxHZ0CT7O5ngTp0TP9mg/HJP_jrm7A

---

Close #885 

<-- Briefly describe the content of this pull request -->

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
