### PR TITLE
fix(settlement): hub disconnect and reconnect causes sequencer to send wrong batch

### DIFF
--- a/settlement/dymension/dymension.go
+++ b/settlement/dymension/dymension.go
@@ -2,8 +2,8 @@ package dymension
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/dymensionxyz/dymint/gerr"
@@ -161,7 +161,7 @@ func (c *Client) SubmitBatch(batch *types.Batch, daClient da.Client, daResult *d
 		err := c.RunWithRetryInfinitely(func() error {
 			err := c.broadcastBatch(msgUpdateState)
 			if err != nil {
-				if errors.Is(err, ErrBatchAlreadySubmitted) {
+				if strings.Contains(err.Error(), ErrBatchAlreadySubmitted) {
 					return retry.Unrecoverable(err)
 				}
 
@@ -179,7 +179,7 @@ func (c *Client) SubmitBatch(batch *types.Batch, daClient da.Client, daResult *d
 		})
 		if err != nil {
 			// this could happen if we timed-out waiting for acceptance, but the batch was indeed submitted
-			if errors.Is(err, ErrBatchAlreadySubmitted) {
+			if strings.Contains(err.Error(), ErrBatchAlreadySubmitted) {
 				includedBatch, _ := c.pollForBatchInclusion(batch.EndHeight) // double check
 				if !includedBatch {
 					return fmt.Errorf("failed to validate batch inclusion")

--- a/settlement/dymension/options.go
+++ b/settlement/dymension/options.go
@@ -30,6 +30,14 @@ func WithBatchAcceptanceTimeout(batchAcceptanceTimeout time.Duration) settlement
 	}
 }
 
+// WithBatchAcceptanceAttempts is an option that sets the number of attempts to check if a batch has been accepted by the settlement layer.
+func WithBatchAcceptanceAttempts(batchAcceptanceAttempts uint) settlement.Option {
+	return func(c settlement.ClientI) {
+		dlc, _ := c.(*Client)
+		dlc.batchAcceptanceAttempts = batchAcceptanceAttempts
+	}
+}
+
 // WithRetryMinDelay is an option that sets the retry function mindelay between hub retry attempts.
 func WithRetryMinDelay(retryMinDelay time.Duration) settlement.Option {
 	return func(c settlement.ClientI) {

--- a/settlement/dymension/types.go
+++ b/settlement/dymension/types.go
@@ -1,0 +1,12 @@
+package dymension
+
+import (
+	"errors"
+
+	dymension "github.com/dymensionxyz/dymension/v3/x/rollapp/types"
+)
+
+var (
+	// if this error is returned, the batch is already submitted
+	ErrBatchAlreadySubmitted = errors.New(dymension.ErrWrongBlockHeight.Error())
+)

--- a/settlement/dymension/types.go
+++ b/settlement/dymension/types.go
@@ -1,12 +1,10 @@
 package dymension
 
 import (
-	"errors"
-
 	dymension "github.com/dymensionxyz/dymension/v3/x/rollapp/types"
 )
 
 var (
 	// if this error is returned, the batch is already submitted
-	ErrBatchAlreadySubmitted = errors.New(dymension.ErrWrongBlockHeight.Error())
+	ErrBatchAlreadySubmitted = dymension.ErrWrongBlockHeight.Error()
 )


### PR DESCRIPTION
1. doesn't break the accpetance loop on rpc errors
2. handle the case where batch was accepted but we timed-out waiting for it

# PR Standards

## Opening a pull request should be able to meet the following requirements

--

PR naming convention: https://hackmd.io/@nZpxHZ0CT7O5ngTp0TP9mg/HJP_jrm7A

---

Close #884 

<-- Briefly describe the content of this pull request -->

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
