### PR TITLE
fix(rpc): fix build with version baked in

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,11 @@
-PACKAGES=$(shell go list ./...)
 BUILDDIR?=$(CURDIR)/build
 OUTPUT?=$(BUILDDIR)/dymint
 
 BUILD_TAGS?=dymint
-
-COMMIT_HASH := $(shell git rev-parse --short HEAD)
-LD_FLAGS = -X github.com/dymensionxyz/dymint/version.DymintGitCommitHash=$(COMMIT_HASH)
-BUILD_FLAGS = -mod=readonly -ldflags "$(LD_FLAGS)"
 CGO_ENABLED ?= 0
 VERSION ?= $(shell git describe --tags --always)
-
 LD_FLAGS = -X github.com/dymensionxyz/dymint/version.BuildVersion=$(VERSION)
-
+BUILD_FLAGS = -mod=readonly -ldflags "$(LD_FLAGS)"
 
 # Process Docker environment varible TARGETPLATFORM 
 # in order to build binary with correspondent ARCH


### PR DESCRIPTION
In the Makefile, the version is not properly passed. Also, `TestNodeHealthRPCPropagation` test doesn't really test anything, so now it will test the result of `/health` endpoint when publishing a data health status event with existing error

# PR Standards

## Opening a pull request should be able to meet the following requirements

--

PR naming convention: https://hackmd.io/@nZpxHZ0CT7O5ngTp0TP9mg/HJP_jrm7A

---

Close #882 

<-- Briefly describe the content of this pull request -->

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated health check endpoints to ensure accurate status reporting.

- **Tests**
  - Enhanced test cases for health check endpoints to improve reliability and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->