### PR TITLE
fix(da): grpc da type fix

### DIFF
--- a/da/da.go
+++ b/da/da.go
@@ -38,6 +38,7 @@ type Client string
 // Data availability clients
 const (
 	Mock     Client = "mock"
+	Grpc     Client = "grpc"
 	Celestia Client = "celestia"
 	Avail    Client = "avail"
 )

--- a/da/grpc/grpc.go
+++ b/da/grpc/grpc.go
@@ -85,7 +85,7 @@ func (m *DataAvailabilityLayerClient) Synced() <-chan struct{} {
 
 // GetClientType returns client type.
 func (d *DataAvailabilityLayerClient) GetClientType() da.Client {
-	return da.Celestia
+	return da.Grpc
 }
 
 // SubmitBatch proxies SubmitBatch request to gRPC server.
@@ -102,7 +102,7 @@ func (d *DataAvailabilityLayerClient) SubmitBatch(batch *types.Batch) da.ResultS
 			Message: resp.Result.Message,
 		},
 		SubmitMetaData: &da.DASubmitMetaData{
-			Client: da.Mock,
+			Client: da.Grpc,
 			Height: resp.Result.DataLayerHeight,
 		},
 	}


### PR DESCRIPTION
# PR Standards

It is not possible to use grpc DA because it fails in DA path da type checks. This PR fixes it by adding the DA type for grpc and using it correctly.

## Opening a pull request should be able to meet the following requirements

--

PR naming convention: https://hackmd.io/@nZpxHZ0CT7O5ngTp0TP9mg/HJP_jrm7A

---

Close #910

<-- Briefly describe the content of this pull request -->

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new data availability client type: `Grpc`.

- **Updates**
  - The `GetClientType` method now returns `Grpc` instead of `Celestia`.
  - The `SubmitMetaData` field's client value has been updated from `Mock` to `Grpc`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->