### PR TITLE
fix(da): submission retry function removed

### DIFF
--- a/config/toml.go
+++ b/config/toml.go
@@ -86,7 +86,7 @@ namespace_id = "{{ .BlockManagerConfig.NamespaceID }}"
 da_config = "{{ .DAConfig }}"
 
 # Celestia config example:
-# da_config = "{\"base_url\":\"http:\/\/127.0.0.1:26658\",\"timeout\":5000000000,\"gas_prices\":0.1,\"auth_token\":\"TOKEN\",\"backoff\":{\"initial_delay\":6000000000,\"max_delay\":6000000000,\"growth_factor\":2},\"retry_attempts\":4,\"retry_delay\":3000000000}"
+# da_config = "{\"base_url\":\"http:\/\/127.0.0.1:26658\",\"timeout\":30000000000,\"gas_prices\":0.1,\"auth_token\":\"TOKEN\",\"backoff\":{\"initial_delay\":6000000000,\"max_delay\":6000000000,\"growth_factor\":2},\"retry_attempts\":4,\"retry_delay\":3000000000}"
 # Avail config example:
 # da_config = "{\"seed\": \"MNEMONIC\", \"api_url\": \"wss://kate.avail.tools/ws\", \"app_id\": 0, \"tip\":10}"
 

--- a/da/celestia/celestia.go
+++ b/da/celestia/celestia.go
@@ -527,24 +527,7 @@ func (c *DataAvailabilityLayerClient) submit(daBlob da.Blob) (uint64, da.Commitm
 	ctx, cancel := context.WithTimeout(c.ctx, c.config.Timeout)
 	defer cancel()
 
-	/*
-		TODO: dry out all retries
-	*/
-
-	var height uint64
-
-	err = retry.Do(
-		func() error {
-			var err error
-			height, err = c.rpc.Submit(ctx, blobs, openrpc.GasPrice(c.config.GasPrices))
-			return err
-		},
-		retry.Context(c.ctx),
-		retry.LastErrorOnly(true),
-		retry.Delay(c.config.RetryDelay),
-		retry.Attempts(uint(c.config.RetryAttempts)),
-		retry.DelayType(retry.FixedDelay),
-	)
+	height, err := c.rpc.Submit(ctx, blobs, openrpc.GasPrice(c.config.GasPrices))
 	if err != nil {
 		return 0, nil, fmt.Errorf("do rpc submit: %w", err)
 	}


### PR DESCRIPTION
# PR Standards

This PR removes the retry function from the DA submission loop, since it delays the submission error and it can lead to confusion when checking the logs without adding anything. It will be retried anyway in an endless loop till it succeeds.

## Opening a pull request should be able to meet the following requirements

--

PR naming convention: https://hackmd.io/@nZpxHZ0CT7O5ngTp0TP9mg/HJP_jrm7A

---

Close #919 

<-- Briefly describe the content of this pull request -->

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
