### PR TITLE
fix(p2p): set gossipsub buffersize to avoid missed blocks when applying big number of blocks in a row (hotfix)

### DIFF
--- a/p2p/client.go
+++ b/p2p/client.go
@@ -41,7 +41,7 @@ const (
 	// blockTopicSuffix is added after namespace to create pubsub topic for block gossiping.
 	blockTopicSuffix = "-block"
 
-	// buffer size used when in gossipSub to consume receive packets. packets are dropped in case buffer overflows. at a block rate of 100ms (the min accepted) it can buffer up to  5 min of blocks.
+	// buffer size used when in gossipSub to consume receive packets. packets are dropped in case buffer overflows. at a block rate of 200ms (the min accepted) it can buffer up to  10 min of blocks.
 	pubsubBufferSize = 3000
 )
 

--- a/p2p/client.go
+++ b/p2p/client.go
@@ -41,7 +41,7 @@ const (
 	// blockTopicSuffix is added after namespace to create pubsub topic for block gossiping.
 	blockTopicSuffix = "-block"
 
-	// buffer size used when consuming packets received from gossipSub. at a min 100ms blockrate it can buffer up to  5 min block
+	// buffer size used when in gossipSub to consume receive packets. packets are dropped in case buffer overflows. at a block rate of 100ms (the min accepted) it can buffer up to  5 min of blocks.
 	pubsubBufferSize = 3000
 )
 

--- a/p2p/gossip.go
+++ b/p2p/gossip.go
@@ -40,7 +40,6 @@ type Gossiper struct {
 	sub        *pubsub.Subscription
 	msgHandler GossipMessageHandler
 	logger     types.Logger
-	bufferSize int
 }
 
 // NewGossiper creates new, ready to use instance of Gossiper.

--- a/p2p/gossip.go
+++ b/p2p/gossip.go
@@ -52,7 +52,6 @@ func NewGossiper(host host.Host, ps *pubsub.PubSub, topicStr string, msgHandler 
 	}
 
 	subscription, err := topic.Subscribe(pubsub.WithBufferSize(pubsubBufferSize))
-
 	if err != nil {
 		return nil, err
 	}

--- a/p2p/gossip.go
+++ b/p2p/gossip.go
@@ -40,18 +40,20 @@ type Gossiper struct {
 	sub        *pubsub.Subscription
 	msgHandler GossipMessageHandler
 	logger     types.Logger
+	bufferSize int
 }
 
 // NewGossiper creates new, ready to use instance of Gossiper.
 //
 // Returned Gossiper object can be used for sending (Publishing) and receiving messages in topic identified by topicStr.
-func NewGossiper(host host.Host, ps *pubsub.PubSub, topicStr string, msgHandler GossipMessageHandler, logger types.Logger, options ...GossiperOption) (*Gossiper, error) {
+func NewGossiper(host host.Host, ps *pubsub.PubSub, topicStr string, msgHandler GossipMessageHandler, pubsubBufferSize int, logger types.Logger, options ...GossiperOption) (*Gossiper, error) {
 	topic, err := ps.Join(topicStr)
 	if err != nil {
 		return nil, err
 	}
 
-	subscription, err := topic.Subscribe()
+	subscription, err := topic.Subscribe(pubsub.WithBufferSize(pubsubBufferSize))
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# PR Standards

## Opening a pull request should be able to meet the following requirements
--

PR naming convention: https://hackmd.io/@nZpxHZ0CT7O5ngTp0TP9mg/HJP_jrm7A

---

Close #972 

<-- Briefly describe the content of this pull request -->

There is a channel in gossipsub implementation, used to consume packets received, that its default size is 32. 
If the occupancy goes over the limit, packets are not added and dropped. 
By setting a bigger buffer size for the channel  we limit the problem, which was happening in cases where out of sync full-nodes where trying to apply long list of blocks, while receiving them from p2p at fast rate.

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
