### PR TITLE
fix(manager): unsubmitted bytes for batch calculation fix

### DIFF
--- a/block/manager.go
+++ b/block/manager.go
@@ -152,12 +152,15 @@ func (m *Manager) Start(ctx context.Context) error {
 
 		// Sequencer must wait till DA is synced to start submitting blobs
 		<-m.DAClient.Synced()
-		nBytes := m.GetUnsubmittedBytes()
-		bytesProducedC := make(chan int)
+
 		err = m.syncFromSettlement()
 		if err != nil {
 			return fmt.Errorf("sync block manager from settlement: %w", err)
 		}
+
+		nBytes := m.GetUnsubmittedBytes()
+		bytesProducedC := make(chan int)
+
 		uerrors.ErrGroupGoLog(eg, m.logger, func() error {
 			return m.SubmitLoop(ctx, bytesProducedC)
 		})


### PR DESCRIPTION
# PR Standards

## Opening a pull request should be able to meet the following requirements

The bytes pending to submit are not calculated correctly on startup, because it is calculated before the last submitted height is initialized. This PR is aimed at fixing it.

--

PR naming convention: https://hackmd.io/@nZpxHZ0CT7O5ngTp0TP9mg/HJP_jrm7A

---

Close #1018 

<-- Briefly describe the content of this pull request -->

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the reliability of the submission process by reordering operations to ensure synchronization is completed before dependent actions are executed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->