### PR TITLE
fix(p2p): update height in blocksync loop

### DIFF
--- a/p2p/client.go
+++ b/p2p/client.go
@@ -597,6 +597,11 @@ func (c *Client) retrieveBlockSyncLoop(ctx context.Context, msgHandler BlockSync
 
 				c.logger.Debug("Blocksync block received ", "height", h)
 				msgHandler(&block)
+				state, err := c.store.LoadState()
+				if err != nil {
+					return
+				}
+				h = max(h, state.NextHeight()-1)
 			}
 			c.blocksReceived.RemoveBlocksReceivedUpToHeight(state.NextHeight())
 		}


### PR DESCRIPTION
# PR Standards

## Opening a pull request should be able to meet the following requirements

This PR fixes an issue when DA is downloading blocks faster than blocksync, which may cause blocksync keeps downloading old blocks already applied. 
--

PR naming convention: https://hackmd.io/@nZpxHZ0CT7O5ngTp0TP9mg/HJP_jrm7A

---

Close #1031 

<-- Briefly describe the content of this pull request -->

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
