### PR TITLE
fix(manager): applylocalblock change mutex

### DIFF
--- a/block/retriever.go
+++ b/block/retriever.go
@@ -95,6 +95,9 @@ func (m *Manager) syncFromDABatch() error {
 }
 
 func (m *Manager) applyLocalBlock(height uint64) error {
+	defer m.retrieverMu.Unlock()
+	m.retrieverMu.Lock()
+
 	block, err := m.Store.LoadBlock(height)
 	if err != nil {
 		return fmt.Errorf("load block: %w", gerrc.ErrNotFound)
@@ -107,12 +110,10 @@ func (m *Manager) applyLocalBlock(height uint64) error {
 		return fmt.Errorf("validate block from local store: height: %d: %w", height, err)
 	}
 
-	m.retrieverMu.Lock()
 	err = m.applyBlock(block, commit, types.BlockMetaData{Source: types.LocalDb})
 	if err != nil {
 		return fmt.Errorf("apply block from local store: height: %d: %w", height, err)
 	}
-	m.retrieverMu.Unlock()
 
 	return nil
 }


### PR DESCRIPTION
# PR Standards

## Opening a pull request should be able to meet the following requirements

--

PR naming convention: https://hackmd.io/@nZpxHZ0CT7O5ngTp0TP9mg/HJP_jrm7A

---

Close #1033 

This PR fixes a bug that causes the retrieve mutex is not unlocked if it fails to apply local block stored in db, which will happen in case the block is already applied  between the time the block is loaded from db and its applied. 

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
