### PR TITLE
fix(rpc): fix websocket subscription panic when no closing error

### DIFF
--- a/rpc/json/ws.go
+++ b/rpc/json/ws.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-
 	tmpubsub "github.com/tendermint/tendermint/libs/pubsub"
 
 	"github.com/dymensionxyz/dymint/types"
@@ -79,12 +78,12 @@ func (h *handler) wsHandler(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			if _, ok := err.(*websocket.CloseError); ok {
 				h.logger.Debug("WebSocket connection closed", "reason", err)
-				err := h.srv.client.EventBus.UnsubscribeAll(r.Context(), remoteAddr)
-				if err != nil && !errors.Is(err, tmpubsub.ErrSubscriptionNotFound) {
-					h.logger.Error("unsubscribe addr from events", "addr", remoteAddr, "err", err)
-				}
 			} else {
 				h.logger.Error("read next WebSocket message", "error", err)
+			}
+			err := h.srv.client.EventBus.UnsubscribeAll(r.Context(), remoteAddr)
+			if err != nil && !errors.Is(err, tmpubsub.ErrSubscriptionNotFound) {
+				h.logger.Error("unsubscribe addr from events", "addr", remoteAddr, "err", err)
 			}
 			break
 		}


### PR DESCRIPTION
# PR Standards

## Opening a pull request should be able to meet the following requirements

In case RPC websocket is closed with an error that is not websocket.CloseError, UnsubscribeAll is not called. This causes the service may try to write to a closed channel, when the error happens and the websocket is closed. 

This PR basically calls UnsubscribeAll when any error

PR naming convention: https://hackmd.io/@nZpxHZ0CT7O5ngTp0TP9mg/HJP_jrm7A

---

Close #1043 

<-- Briefly describe the content of this pull request -->

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
