### PR TITLE
fix(store): improve pruning to avoid skipped heights

### DIFF
--- a/block/block.go
+++ b/block/block.go
@@ -98,7 +98,7 @@ func (m *Manager) applyBlock(block *types.Block, commit *types.Commit, blockMeta
 
 	// Prune old heights, if requested by ABCI app.
 	if 0 < retainHeight {
-		err = m.PruneBlocks(uint64(retainHeight))
+		_, err := m.PruneBlocks(uint64(retainHeight))
 		if err != nil {
 			m.logger.Error("prune blocks", "retain_height", retainHeight, "err", err)
 		}

--- a/block/manager.go
+++ b/block/manager.go
@@ -177,7 +177,7 @@ func (m *Manager) Start(ctx context.Context) error {
 	}
 
 	/* ----------------------------- sequencer mode ----------------------------- */
-	// Subscribe to batch events, to update last submitted height in case batch confirmation was lost. This could happen if the sequencer crash/restarted just after submitting a batch to the settelement and by the time we query the last batch, this batch wasn't accepted yet. 
+	// Subscribe to batch events, to update last submitted height in case batch confirmation was lost. This could happen if the sequencer crash/restarted just after submitting a batch to the settelement and by the time we query the last batch, this batch wasn't accepted yet.
 	go uevent.MustSubscribe(ctx, m.Pubsub, "updateSubmittedHeightLoop", settlement.EventQueryNewSettlementBatchAccepted, m.UpdateLastSubmittedHeight, m.logger)
 
 	// Sequencer must wait till DA is synced to start submitting blobs

--- a/block/manager.go
+++ b/block/manager.go
@@ -177,7 +177,7 @@ func (m *Manager) Start(ctx context.Context) error {
 	}
 
 	/* ----------------------------- sequencer mode ----------------------------- */
-	// Subscribe to batch events, to update last submitted height in case batch confirmation was lost. This could happen if the sequencer crash/restarted just after submitting a batch to the settelement and by the time we query the last batch, this batch wasn't accepted yet.
+	// Subscribe to batch events, to update last submitted height in case batch confirmation was lost. This could happen if the sequencer crash/restarted just after submitting a batch to the settlement and by the time we query the last batch, this batch wasn't accepted yet.
 	go uevent.MustSubscribe(ctx, m.Pubsub, "updateSubmittedHeightLoop", settlement.EventQueryNewSettlementBatchAccepted, m.UpdateLastSubmittedHeight, m.logger)
 
 	// Sequencer must wait till DA is synced to start submitting blobs

--- a/block/pruning.go
+++ b/block/pruning.go
@@ -3,23 +3,19 @@ package block
 import (
 	"context"
 	"fmt"
-
-	"github.com/dymensionxyz/gerr-cosmos/gerrc"
 )
 
 func (m *Manager) PruneBlocks(retainHeight uint64) error {
 	if m.IsProposer() && m.NextHeightToSubmit() < retainHeight { // do not delete anything that we might submit in future
-		return fmt.Errorf("cannot prune blocks before they have been submitted: retain height %d: next height to submit: %d: %w",
-			retainHeight,
-			m.NextHeightToSubmit(),
-			gerrc.ErrInvalidArgument)
+		m.logger.Debug("cannot prune blocks before they have been submitted. using height last submitted height for pruning", "retain_height", retainHeight, "height_to_submit", m.NextHeightToSubmit())
+		retainHeight = m.NextHeightToSubmit() - 1
 	}
 
 	err := m.P2PClient.RemoveBlocks(context.Background(), m.State.BaseHeight, retainHeight)
 	if err != nil {
 		m.logger.Error("pruning blocksync store", "retain_height", retainHeight, "err", err)
 	}
-	pruned, err := m.Store.PruneBlocks(m.State.BaseHeight, retainHeight)
+	pruned, err := m.Store.PruneBlocks(m.State.BaseHeight, retainHeight, m.logger)
 	if err != nil {
 		return fmt.Errorf("prune block store: %w", err)
 	}

--- a/block/pruning.go
+++ b/block/pruning.go
@@ -6,12 +6,10 @@ import (
 )
 
 func (m *Manager) PruneBlocks(retainHeight uint64) (uint64, error) {
-	if m.IsProposer() && m.NextHeightToSubmit() < retainHeight { // do not delete anything that we might submit in future
+	nextSubmissionHeight := m.NextHeightToSubmit()
+	if m.IsProposer() && nextSubmissionHeight < retainHeight { // do not delete anything that we might submit in future
 		m.logger.Debug("cannot prune blocks before they have been submitted. using height last submitted height for pruning", "retain_height", retainHeight, "height_to_submit", m.NextHeightToSubmit())
-		retainHeight = m.NextHeightToSubmit() - 1
-		if retainHeight <= m.State.BaseHeight {
-			return 0, nil
-		}
+		retainHeight = nextSubmissionHeight
 	}
 
 	err := m.P2PClient.RemoveBlocks(context.Background(), m.State.BaseHeight, retainHeight)

--- a/block/pruning.go
+++ b/block/pruning.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 )
 
+// PruneBlocks all block related data from dymint store up to retainHeight. It returns the number of blocks pruned, used for testing.
 func (m *Manager) PruneBlocks(retainHeight uint64) (uint64, error) {
 	nextSubmissionHeight := m.NextHeightToSubmit()
 	if m.IsProposer() && nextSubmissionHeight < retainHeight { // do not delete anything that we might submit in future

--- a/block/pruning.go
+++ b/block/pruning.go
@@ -31,5 +31,7 @@ func (m *Manager) PruneBlocks(retainHeight uint64) (uint64, error) {
 		return 0, fmt.Errorf("save state: %w", err)
 	}
 
+	m.logger.Info("pruned blocks", "pruned", pruned, "retain_height", retainHeight)
+
 	return pruned, nil
 }

--- a/block/pruning.go
+++ b/block/pruning.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-// PruneBlocks all block related data from dymint store up to retainHeight. It returns the number of blocks pruned, used for testing.
+// PruneBlocks prune all block related data from dymint store up to (but not including) retainHeight. It returns the number of blocks pruned, used for testing.
 func (m *Manager) PruneBlocks(retainHeight uint64) (uint64, error) {
 	nextSubmissionHeight := m.NextHeightToSubmit()
 	if m.IsProposer() && nextSubmissionHeight < retainHeight { // do not delete anything that we might submit in future

--- a/block/pruning.go
+++ b/block/pruning.go
@@ -18,7 +18,7 @@ func (m *Manager) PruneBlocks(retainHeight uint64) (uint64, error) {
 	if err != nil {
 		m.logger.Error("pruning blocksync store", "retain_height", retainHeight, "err", err)
 	}
-	pruned, err := m.Store.PruneBlocks(m.State.BaseHeight, retainHeight, m.logger)
+	pruned, err := m.Store.PruneStore(m.State.BaseHeight, retainHeight, m.logger)
 	if err != nil {
 		return 0, fmt.Errorf("prune block store: %w", err)
 	}

--- a/block/pruning_test.go
+++ b/block/pruning_test.go
@@ -67,10 +67,16 @@ func TestPruningRetainHeight(t *testing.T) {
 
 	validRetainHeight := lastSubmitted + 1 // the max possible valid retain height
 	for i := validRetainHeight + 1; i < manager.State.Height(); i++ {
-		err = manager.PruneBlocks(i)
-		require.Error(err) // cannot prune blocks before they have been submitted
+		expectedPruned := uint64(0)
+		if lastSubmitted >= manager.State.BaseHeight {
+			expectedPruned = lastSubmitted - manager.State.BaseHeight
+		}
+		pruned, err := manager.PruneBlocks(i)
+		require.NoError(err)
+		assert.Equal(t, expectedPruned, pruned)
+
 	}
 
-	err = manager.PruneBlocks(validRetainHeight)
+	_, err = manager.PruneBlocks(validRetainHeight)
 	require.NoError(err)
 }

--- a/block/submit.go
+++ b/block/submit.go
@@ -117,8 +117,8 @@ func SubmitLoopInner(
 						logger.Error("Create and submit batch", "err", err, "pending", pending)
 						panic(err)
 					}
-					// this could happen if we timed-out waiting for acceptance in the previous iteration, but the batch was indeed submitted. 
-                    // we panic here cause restarting may reset the last batch submitted counter and the sequencer can potentially resume submitting batches.
+					// this could happen if we timed-out waiting for acceptance in the previous iteration, but the batch was indeed submitted.
+					// we panic here cause restarting may reset the last batch submitted counter and the sequencer can potentially resume submitting batches.
 					if errors.Is(err, gerrc.ErrAlreadyExists) {
 						logger.Debug("Batch already accepted", "err", err, "pending", pending)
 						panic(err)
@@ -273,7 +273,7 @@ func (m *Manager) GetUnsubmittedBlocks() uint64 {
 	return m.State.Height() - m.LastSubmittedHeight.Load()
 }
 
-// UpdateLastSubmittedHeight will update last height submitted height upon events. 
+// UpdateLastSubmittedHeight will update last height submitted height upon events.
 // This may be necessary in case we crashed/restarted before getting response for our submission to the settlement layer.
 func (m *Manager) UpdateLastSubmittedHeight(event pubsub.Message) {
 	eventData, ok := event.Data().(*settlement.EventDataNewBatchAccepted)

--- a/p2p/client.go
+++ b/p2p/client.go
@@ -230,14 +230,14 @@ func (c *Client) RemoveBlocks(ctx context.Context, from, to uint64) error {
 	}
 
 	for h := from; h < to; h++ {
-
 		cid, err := c.store.LoadBlockCid(h)
 		if err != nil {
-			return fmt.Errorf("load block id from store %d: %w", h, err)
+			c.logger.Error("load blocksync block id from store", "height", h, "error", err)
+			continue
 		}
 		err = c.blocksync.DeleteBlock(ctx, cid)
 		if err != nil {
-			return fmt.Errorf("remove block height %d: %w", h, err)
+			c.logger.Error("remove blocksync block", "height", h, "err", err)
 		}
 	}
 	return nil

--- a/p2p/client.go
+++ b/p2p/client.go
@@ -3,6 +3,7 @@ package p2p
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -231,6 +232,9 @@ func (c *Client) RemoveBlocks(ctx context.Context, from, to uint64) error {
 
 	for h := from; h < to; h++ {
 		cid, err := c.store.LoadBlockCid(h)
+		if errors.Is(err, gerrc.ErrNotFound) {
+			continue
+		}
 		if err != nil {
 			c.logger.Error("load blocksync block id from store", "height", h, "error", err)
 			continue

--- a/store/pruning.go
+++ b/store/pruning.go
@@ -7,7 +7,7 @@ import (
 	"github.com/dymensionxyz/gerr-cosmos/gerrc"
 )
 
-// PruneBlocks removes block up to (but not including) a height. It returns number of blocks pruned.
+// PruneStore removes blocks up to (but not including) a height. It returns number of blocks pruned.
 func (s *DefaultStore) PruneStore(from, to uint64, logger types.Logger) (uint64, error) {
 	if from <= 0 {
 		return 0, fmt.Errorf("from height must be greater than 0: %w", gerrc.ErrInvalidArgument)

--- a/store/pruning.go
+++ b/store/pruning.go
@@ -65,7 +65,6 @@ func (s *DefaultStore) pruneBlocks(from, to uint64) (uint64, error) {
 
 // pruneResponses prunes block execution responses from store
 func (s *DefaultStore) pruneResponses(from, to uint64) (uint64, error) {
-
 	pruneResponses := func(batch KVBatch, height uint64) error {
 		if err := batch.Delete(getResponsesKey(height)); err != nil {
 			return err
@@ -79,7 +78,6 @@ func (s *DefaultStore) pruneResponses(from, to uint64) (uint64, error) {
 
 // pruneSequencers prunes sequencers from store
 func (s *DefaultStore) pruneSequencers(from, to uint64) (uint64, error) {
-
 	pruneSequencers := func(batch KVBatch, height uint64) error {
 		if err := batch.Delete(getSequencersKey(height)); err != nil {
 			return err
@@ -92,7 +90,6 @@ func (s *DefaultStore) pruneSequencers(from, to uint64) (uint64, error) {
 
 // pruneCids prunes content identifiers from store
 func (s *DefaultStore) pruneCids(from, to uint64) (uint64, error) {
-
 	pruneCids := func(batch KVBatch, height uint64) error {
 		if err := batch.Delete(getCidKey(height)); err != nil {
 			return err

--- a/store/pruning.go
+++ b/store/pruning.go
@@ -66,10 +66,7 @@ func (s *DefaultStore) pruneBlocks(from, to uint64, logger types.Logger) (uint64
 // pruneResponses prunes block execution responses from store
 func (s *DefaultStore) pruneResponses(from, to uint64, logger types.Logger) (uint64, error) {
 	pruneResponses := func(batch KVBatch, height uint64) error {
-		if err := batch.Delete(getResponsesKey(height)); err != nil {
-			return err
-		}
-		return nil
+		return batch.Delete(getResponsesKey(height))
 	}
 
 	prunedResponses, err := s.pruneHeights(from, to, pruneResponses, logger)
@@ -79,10 +76,7 @@ func (s *DefaultStore) pruneResponses(from, to uint64, logger types.Logger) (uin
 // pruneSequencers prunes sequencers from store
 func (s *DefaultStore) pruneSequencers(from, to uint64, logger types.Logger) (uint64, error) {
 	pruneSequencers := func(batch KVBatch, height uint64) error {
-		if err := batch.Delete(getSequencersKey(height)); err != nil {
-			return err
-		}
-		return nil
+		return batch.Delete(getSequencersKey(height))
 	}
 	prunedSequencers, err := s.pruneHeights(from, to, pruneSequencers, logger)
 	return prunedSequencers, err
@@ -91,10 +85,7 @@ func (s *DefaultStore) pruneSequencers(from, to uint64, logger types.Logger) (ui
 // pruneCids prunes content identifiers from store
 func (s *DefaultStore) pruneCids(from, to uint64, logger types.Logger) (uint64, error) {
 	pruneCids := func(batch KVBatch, height uint64) error {
-		if err := batch.Delete(getCidKey(height)); err != nil {
-			return err
-		}
-		return nil
+		return batch.Delete(getCidKey(height))
 	}
 	prunedCids, err := s.pruneHeights(from, to, pruneCids, logger)
 	return prunedCids, err

--- a/store/pruning.go
+++ b/store/pruning.go
@@ -8,7 +8,7 @@ import (
 )
 
 // PruneBlocks removes block up to (but not including) a height. It returns number of blocks pruned.
-func (s *DefaultStore) PruneBlocks(from, to uint64, logger types.Logger) (uint64, error) {
+func (s *DefaultStore) PruneStore(from, to uint64, logger types.Logger) (uint64, error) {
 	if from <= 0 {
 		return 0, fmt.Errorf("from height must be greater than 0: %w", gerrc.ErrInvalidArgument)
 	}
@@ -17,6 +17,31 @@ func (s *DefaultStore) PruneBlocks(from, to uint64, logger types.Logger) (uint64
 		return 0, fmt.Errorf("to height must be greater than from height: to: %d: from: %d: %w", to, from, gerrc.ErrInvalidArgument)
 	}
 
+	prunedBlocks, err := s.pruneBlocks(from, to)
+	if err != nil {
+		logger.Error("pruning blocks", "from", from, "to", to, "blocks pruned", prunedBlocks, "err", err)
+	}
+
+	prunedResponses, err := s.pruneResponses(from, to)
+	if err != nil {
+		logger.Error("pruning responses", "from", from, "to", to, "responses pruned", prunedResponses, "err", err)
+	}
+
+	prunedSequencers, err := s.pruneSequencers(from, to)
+	if err != nil {
+		logger.Error("pruning sequencers", "from", from, "to", to, "sequencers pruned", prunedSequencers, "err", err)
+	}
+
+	prunedCids, err := s.pruneCids(from, to)
+	if err != nil {
+		logger.Error("pruning block sync identifiers", "from", from, "to", to, "cids pruned", prunedCids, "err", err)
+	}
+
+	return prunedBlocks, nil
+}
+
+// pruneBlocks prunes all store entries that are stored along blocks (blocks,commit and block hash)
+func (s *DefaultStore) pruneBlocks(from, to uint64) (uint64, error) {
 	pruneBlocks := func(batch KVBatch, height uint64) error {
 		hash, err := s.loadHashFromIndex(height)
 		if err != nil {
@@ -34,6 +59,13 @@ func (s *DefaultStore) PruneBlocks(from, to uint64, logger types.Logger) (uint64
 		return nil
 	}
 
+	prunedBlocks, err := s.pruneHeights(from, to, pruneBlocks)
+	return prunedBlocks, err
+}
+
+// pruneResponses prunes block execution responses from store
+func (s *DefaultStore) pruneResponses(from, to uint64) (uint64, error) {
+
 	pruneResponses := func(batch KVBatch, height uint64) error {
 		if err := batch.Delete(getResponsesKey(height)); err != nil {
 			return err
@@ -41,12 +73,25 @@ func (s *DefaultStore) PruneBlocks(from, to uint64, logger types.Logger) (uint64
 		return nil
 	}
 
+	prunedResponses, err := s.pruneHeights(from, to, pruneResponses)
+	return prunedResponses, err
+}
+
+// pruneSequencers prunes sequencers from store
+func (s *DefaultStore) pruneSequencers(from, to uint64) (uint64, error) {
+
 	pruneSequencers := func(batch KVBatch, height uint64) error {
 		if err := batch.Delete(getSequencersKey(height)); err != nil {
 			return err
 		}
 		return nil
 	}
+	prunedSequencers, err := s.pruneHeights(from, to, pruneSequencers)
+	return prunedSequencers, err
+}
+
+// pruneCids prunes content identifiers from store
+func (s *DefaultStore) pruneCids(from, to uint64) (uint64, error) {
 
 	pruneCids := func(batch KVBatch, height uint64) error {
 		if err := batch.Delete(getCidKey(height)); err != nil {
@@ -54,30 +99,12 @@ func (s *DefaultStore) PruneBlocks(from, to uint64, logger types.Logger) (uint64
 		}
 		return nil
 	}
-
-	prunedBlocks, err := s.pruneIteration(from, to, pruneBlocks)
-	if err != nil {
-		logger.Error("pruning blocks", "from", from, "to", to, "err", err)
-	}
-
-	_, err = s.pruneIteration(from, to, pruneResponses)
-	if err != nil {
-		logger.Error("pruning responses", "from", from, "to", to, "err", err)
-	}
-
-	_, err = s.pruneIteration(from, to, pruneSequencers)
-	if err != nil {
-		logger.Error("pruning sequencers", "from", from, "to", to, "err", err)
-	}
-
-	_, err = s.pruneIteration(from, to, pruneCids)
-	if err != nil {
-		logger.Error("pruning cids", "from", from, "to", to, "err", err)
-	}
-	return prunedBlocks, nil
+	prunedCids, err := s.pruneHeights(from, to, pruneCids)
+	return prunedCids, err
 }
 
-func (s *DefaultStore) pruneIteration(from, to uint64, prune func(batch KVBatch, height uint64) error) (uint64, error) {
+// pruneHeights is the common function for all pruning that iterates through all heights and prunes according to the pruning function set
+func (s *DefaultStore) pruneHeights(from, to uint64, prune func(batch KVBatch, height uint64) error) (uint64, error) {
 	pruned := uint64(0)
 
 	batch := s.db.NewBatch()

--- a/store/pruning.go
+++ b/store/pruning.go
@@ -3,11 +3,12 @@ package store
 import (
 	"fmt"
 
+	"github.com/dymensionxyz/dymint/types"
 	"github.com/dymensionxyz/gerr-cosmos/gerrc"
 )
 
 // PruneBlocks removes block up to (but not including) a height. It returns number of blocks pruned.
-func (s *DefaultStore) PruneBlocks(from, to uint64) (uint64, error) {
+func (s *DefaultStore) PruneBlocks(from, to uint64, logger types.Logger) (uint64, error) {
 	if from <= 0 {
 		return 0, fmt.Errorf("from height must be greater than 0: %w", gerrc.ErrInvalidArgument)
 	}
@@ -16,7 +17,71 @@ func (s *DefaultStore) PruneBlocks(from, to uint64) (uint64, error) {
 		return 0, fmt.Errorf("to height must be greater than from height: to: %d: from: %d: %w", to, from, gerrc.ErrInvalidArgument)
 	}
 
+	pruneBlocks := func(batch KVBatch, height uint64) error {
+		hash, err := s.loadHashFromIndex(height)
+		if err != nil {
+			return err
+		}
+		if err := batch.Delete(getBlockKey(hash)); err != nil {
+			return err
+		}
+		if err := batch.Delete(getCommitKey(hash)); err != nil {
+			return err
+		}
+		if err := batch.Delete(getIndexKey(height)); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	pruneResponses := func(batch KVBatch, height uint64) error {
+		if err := batch.Delete(getResponsesKey(height)); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	pruneSequencers := func(batch KVBatch, height uint64) error {
+		if err := batch.Delete(getSequencersKey(height)); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	pruneCids := func(batch KVBatch, height uint64) error {
+		if err := batch.Delete(getCidKey(height)); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	prunedBlocks, err := s.pruneIteration(from, to, pruneBlocks)
+	if err != nil {
+		logger.Error("pruning blocks", "from", from, "to", to, "err", err)
+	}
+
+	_, err = s.pruneIteration(from, to, pruneResponses)
+	if err != nil {
+		logger.Error("pruning responses", "from", from, "to", to, "err", err)
+	}
+
+	_, err = s.pruneIteration(from, to, pruneSequencers)
+	if err != nil {
+		logger.Error("pruning sequencers", "from", from, "to", to, "err", err)
+	}
+
+	_, err = s.pruneIteration(from, to, pruneCids)
+	if err != nil {
+		logger.Error("pruning cids", "from", from, "to", to, "err", err)
+	}
+	return prunedBlocks, nil
+
+}
+
+func (s *DefaultStore) pruneIteration(from, to uint64, prune func(batch KVBatch, height uint64) error) (uint64, error) {
+
 	pruned := uint64(0)
+
 	batch := s.db.NewBatch()
 	defer batch.Discard()
 
@@ -29,29 +94,7 @@ func (s *DefaultStore) PruneBlocks(from, to uint64) (uint64, error) {
 	}
 
 	for h := from; h < to; h++ {
-		hash, err := s.loadHashFromIndex(h)
-		if err != nil {
-			continue
-		}
-		if err := batch.Delete(getBlockKey(hash)); err != nil {
-			return 0, err
-		}
-		if err := batch.Delete(getCommitKey(hash)); err != nil {
-			return 0, err
-		}
-		if err := batch.Delete(getIndexKey(h)); err != nil {
-			return 0, err
-		}
-		if err := batch.Delete(getResponsesKey(h)); err != nil {
-			return 0, err
-		}
-		if err := batch.Delete(getSequencersKey(h)); err != nil {
-			return 0, err
-		}
-		if err := batch.Delete(getCidKey(h)); err != nil {
-			return 0, err
-		}
-
+		prune(batch, h)
 		pruned++
 
 		// flush every 1000 blocks to avoid batches becoming too large
@@ -63,11 +106,13 @@ func (s *DefaultStore) PruneBlocks(from, to uint64) (uint64, error) {
 			batch.Discard()
 			batch = s.db.NewBatch()
 		}
-	}
 
+	}
 	err := flush(batch, to)
 	if err != nil {
 		return 0, err
 	}
+
 	return pruned, nil
+
 }

--- a/store/pruning.go
+++ b/store/pruning.go
@@ -94,7 +94,10 @@ func (s *DefaultStore) pruneIteration(from, to uint64, prune func(batch KVBatch,
 	}
 
 	for h := from; h < to; h++ {
-		prune(batch, h)
+		err := prune(batch, h)
+		if err != nil {
+			continue
+		}
 		pruned++
 
 		// flush every 1000 blocks to avoid batches becoming too large

--- a/store/pruning.go
+++ b/store/pruning.go
@@ -17,22 +17,22 @@ func (s *DefaultStore) PruneStore(from, to uint64, logger types.Logger) (uint64,
 		return 0, fmt.Errorf("to height must be greater than from height: to: %d: from: %d: %w", to, from, gerrc.ErrInvalidArgument)
 	}
 
-	prunedBlocks, err := s.pruneBlocks(from, to)
+	prunedBlocks, err := s.pruneBlocks(from, to, logger)
 	if err != nil {
 		logger.Error("pruning blocks", "from", from, "to", to, "blocks pruned", prunedBlocks, "err", err)
 	}
 
-	prunedResponses, err := s.pruneResponses(from, to)
+	prunedResponses, err := s.pruneResponses(from, to, logger)
 	if err != nil {
 		logger.Error("pruning responses", "from", from, "to", to, "responses pruned", prunedResponses, "err", err)
 	}
 
-	prunedSequencers, err := s.pruneSequencers(from, to)
+	prunedSequencers, err := s.pruneSequencers(from, to, logger)
 	if err != nil {
 		logger.Error("pruning sequencers", "from", from, "to", to, "sequencers pruned", prunedSequencers, "err", err)
 	}
 
-	prunedCids, err := s.pruneCids(from, to)
+	prunedCids, err := s.pruneCids(from, to, logger)
 	if err != nil {
 		logger.Error("pruning block sync identifiers", "from", from, "to", to, "cids pruned", prunedCids, "err", err)
 	}
@@ -41,7 +41,7 @@ func (s *DefaultStore) PruneStore(from, to uint64, logger types.Logger) (uint64,
 }
 
 // pruneBlocks prunes all store entries that are stored along blocks (blocks,commit and block hash)
-func (s *DefaultStore) pruneBlocks(from, to uint64) (uint64, error) {
+func (s *DefaultStore) pruneBlocks(from, to uint64, logger types.Logger) (uint64, error) {
 	pruneBlocks := func(batch KVBatch, height uint64) error {
 		hash, err := s.loadHashFromIndex(height)
 		if err != nil {
@@ -59,12 +59,12 @@ func (s *DefaultStore) pruneBlocks(from, to uint64) (uint64, error) {
 		return nil
 	}
 
-	prunedBlocks, err := s.pruneHeights(from, to, pruneBlocks)
+	prunedBlocks, err := s.pruneHeights(from, to, pruneBlocks, logger)
 	return prunedBlocks, err
 }
 
 // pruneResponses prunes block execution responses from store
-func (s *DefaultStore) pruneResponses(from, to uint64) (uint64, error) {
+func (s *DefaultStore) pruneResponses(from, to uint64, logger types.Logger) (uint64, error) {
 	pruneResponses := func(batch KVBatch, height uint64) error {
 		if err := batch.Delete(getResponsesKey(height)); err != nil {
 			return err
@@ -72,36 +72,36 @@ func (s *DefaultStore) pruneResponses(from, to uint64) (uint64, error) {
 		return nil
 	}
 
-	prunedResponses, err := s.pruneHeights(from, to, pruneResponses)
+	prunedResponses, err := s.pruneHeights(from, to, pruneResponses, logger)
 	return prunedResponses, err
 }
 
 // pruneSequencers prunes sequencers from store
-func (s *DefaultStore) pruneSequencers(from, to uint64) (uint64, error) {
+func (s *DefaultStore) pruneSequencers(from, to uint64, logger types.Logger) (uint64, error) {
 	pruneSequencers := func(batch KVBatch, height uint64) error {
 		if err := batch.Delete(getSequencersKey(height)); err != nil {
 			return err
 		}
 		return nil
 	}
-	prunedSequencers, err := s.pruneHeights(from, to, pruneSequencers)
+	prunedSequencers, err := s.pruneHeights(from, to, pruneSequencers, logger)
 	return prunedSequencers, err
 }
 
 // pruneCids prunes content identifiers from store
-func (s *DefaultStore) pruneCids(from, to uint64) (uint64, error) {
+func (s *DefaultStore) pruneCids(from, to uint64, logger types.Logger) (uint64, error) {
 	pruneCids := func(batch KVBatch, height uint64) error {
 		if err := batch.Delete(getCidKey(height)); err != nil {
 			return err
 		}
 		return nil
 	}
-	prunedCids, err := s.pruneHeights(from, to, pruneCids)
+	prunedCids, err := s.pruneHeights(from, to, pruneCids, logger)
 	return prunedCids, err
 }
 
 // pruneHeights is the common function for all pruning that iterates through all heights and prunes according to the pruning function set
-func (s *DefaultStore) pruneHeights(from, to uint64, prune func(batch KVBatch, height uint64) error) (uint64, error) {
+func (s *DefaultStore) pruneHeights(from, to uint64, prune func(batch KVBatch, height uint64) error, logger types.Logger) (uint64, error) {
 	pruned := uint64(0)
 
 	batch := s.db.NewBatch()
@@ -118,6 +118,7 @@ func (s *DefaultStore) pruneHeights(from, to uint64, prune func(batch KVBatch, h
 	for h := from; h < to; h++ {
 		err := prune(batch, h)
 		if err != nil {
+			logger.Debug("unable to prune", "height", h, "err", err)
 			continue
 		}
 		pruned++

--- a/store/pruning.go
+++ b/store/pruning.go
@@ -75,11 +75,9 @@ func (s *DefaultStore) PruneBlocks(from, to uint64, logger types.Logger) (uint64
 		logger.Error("pruning cids", "from", from, "to", to, "err", err)
 	}
 	return prunedBlocks, nil
-
 }
 
 func (s *DefaultStore) pruneIteration(from, to uint64, prune func(batch KVBatch, height uint64) error) (uint64, error) {
-
 	pruned := uint64(0)
 
 	batch := s.db.NewBatch()
@@ -117,5 +115,4 @@ func (s *DefaultStore) pruneIteration(from, to uint64, prune func(batch KVBatch,
 	}
 
 	return pruned, nil
-
 }

--- a/store/pruning_test.go
+++ b/store/pruning_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
 	"github.com/stretchr/testify/assert"
+	"github.com/tendermint/tendermint/libs/log"
 )
 
 func TestStorePruning(t *testing.T) {
@@ -90,7 +91,7 @@ func TestStorePruning(t *testing.T) {
 				assert.NoError(err)
 			}
 
-			_, err := bstore.PruneBlocks(c.from, c.to)
+			_, err := bstore.PruneBlocks(c.from, c.to, log.NewNopLogger())
 			if c.shouldError {
 				assert.Error(err)
 				return

--- a/store/pruning_test.go
+++ b/store/pruning_test.go
@@ -130,7 +130,7 @@ func TestStorePruning(t *testing.T) {
 				assert.NoError(err)
 			}
 
-			_, err := bstore.PruneBlocks(c.from, c.to, log.NewNopLogger())
+			_, err := bstore.PruneStore(c.from, c.to, log.NewNopLogger())
 			if c.shouldError {
 				assert.Error(err)
 				return

--- a/store/pruning_test.go
+++ b/store/pruning_test.go
@@ -10,6 +10,8 @@ import (
 	mh "github.com/multiformats/go-multihash"
 	"github.com/stretchr/testify/assert"
 	"github.com/tendermint/tendermint/libs/log"
+	"github.com/tendermint/tendermint/proto/tendermint/state"
+	"golang.org/x/exp/rand"
 )
 
 func TestStorePruning(t *testing.T) {
@@ -61,33 +63,70 @@ func TestStorePruning(t *testing.T) {
 			assert := assert.New(t)
 			bstore := store.New(store.NewDefaultInMemoryKVStore())
 
-			savedHeights := make(map[uint64]bool)
-			for _, block := range c.blocks {
-				_, err := bstore.SaveBlock(block, &types.Commit{}, nil)
-				assert.NoError(err)
-				savedHeights[block.Header.Height] = true
-				blockBytes, err := block.MarshalBinary()
-				assert.NoError(err)
-				// Create a cid manually by specifying the 'prefix' parameters
-				pref := &cid.Prefix{
-					Codec:    cid.DagProtobuf,
-					MhLength: -1,
-					MhType:   mh.SHA2_256,
-					Version:  1,
-				}
-				cid, err := pref.Sum(blockBytes)
-				assert.NoError(err)
-				_, err = bstore.SaveBlockCid(block.Header.Height, cid, nil)
-				assert.NoError(err)
+			savedBlockHeights := make(map[uint64]bool)
+			savedRespHeights := make(map[uint64]bool)
+			savedSeqHeights := make(map[uint64]bool)
+			savedCidHeights := make(map[uint64]bool)
 
-				// TODO: add block responses and commits
+			for _, block := range c.blocks {
+
+				_, err := bstore.SaveBlock(block, &types.Commit{Height: block.Header.Height}, nil)
+				assert.NoError(err)
+				savedBlockHeights[block.Header.Height] = true
+
+				// generate and store block responses randomly for block heights
+				if randBool() {
+					_, err = bstore.SaveBlockResponses(block.Header.Height, &state.ABCIResponses{}, nil)
+					savedRespHeights[block.Header.Height] = true
+					assert.NoError(err)
+				}
+
+				// generate and store sequencers randomly for block heights
+				if randBool() {
+					_, err = bstore.SaveSequencers(block.Header.Height, &types.SequencerSet{}, nil)
+					savedSeqHeights[block.Header.Height] = true
+					assert.NoError(err)
+				}
+
+				// generate and store cids randomly for block heights
+				if randBool() {
+					// generate cid from block
+					blockBytes, err := block.MarshalBinary()
+					assert.NoError(err)
+					// Create a cid manually by specifying the 'prefix' parameters
+					pref := &cid.Prefix{
+						Codec:    cid.DagProtobuf,
+						MhLength: -1,
+						MhType:   mh.SHA2_256,
+						Version:  1,
+					}
+					cid, err := pref.Sum(blockBytes)
+					assert.NoError(err)
+					_, err = bstore.SaveBlockCid(block.Header.Height, cid, nil)
+					assert.NoError(err)
+					savedCidHeights[block.Header.Height] = true
+				}
+
 			}
 
-			// And then feed it some data
-			// expectedCid, err := pref.Sum(block)
-			// Validate all blocks are saved
-			for k := range savedHeights {
+			// Validate everything is saved
+			for k := range savedBlockHeights {
 				_, err := bstore.LoadBlock(k)
+				assert.NoError(err)
+			}
+
+			for k := range savedRespHeights {
+				_, err := bstore.LoadBlockResponses(k)
+				assert.NoError(err)
+			}
+
+			for k := range savedSeqHeights {
+				_, err := bstore.LoadSequencers(k)
+				assert.NoError(err)
+			}
+
+			for k := range savedCidHeights {
+				_, err := bstore.LoadBlockCid(k)
 				assert.NoError(err)
 			}
 
@@ -100,27 +139,54 @@ func TestStorePruning(t *testing.T) {
 			assert.NoError(err)
 
 			// Validate only blocks in the range are pruned
-			for k := range savedHeights {
+			for k := range savedBlockHeights {
 				if k >= c.from && k < c.to { // k < c.to is the exclusion test
 					_, err := bstore.LoadBlock(k)
 					assert.Error(err, "Block at height %d should be pruned", k)
 
-					_, err = bstore.LoadBlockResponses(k)
-					assert.Error(err, "BlockResponse at height %d should be pruned", k)
-
 					_, err = bstore.LoadCommit(k)
 					assert.Error(err, "Commit at height %d should be pruned", k)
-
-					_, err = bstore.LoadBlockCid(k)
-					assert.Error(err, "Cid at height %d should be pruned", k)
 
 				} else {
 					_, err := bstore.LoadBlock(k)
 					assert.NoError(err)
 
-					_, err = bstore.LoadBlockCid(k)
+					_, err = bstore.LoadCommit(k)
 					assert.NoError(err)
 
+				}
+			}
+
+			// Validate only block responses in the range are pruned
+			for k := range savedRespHeights {
+				if k >= c.from && k < c.to { // k < c.to is the exclusion test
+					_, err = bstore.LoadBlockResponses(k)
+					assert.Error(err, "Block response at height %d should be pruned", k)
+				} else {
+					_, err = bstore.LoadBlockResponses(k)
+					assert.NoError(err)
+				}
+			}
+
+			// Validate only sequencers in the range are pruned
+			for k := range savedSeqHeights {
+				if k >= c.from && k < c.to { // k < c.to is the exclusion test
+					_, err = bstore.LoadSequencers(k)
+					assert.Error(err, "Block cid at height %d should be pruned", k)
+				} else {
+					_, err = bstore.LoadSequencers(k)
+					assert.NoError(err)
+				}
+			}
+
+			// Validate only block cids in the range are pruned
+			for k := range savedCidHeights {
+				if k >= c.from && k < c.to { // k < c.to is the exclusion test
+					_, err = bstore.LoadBlockCid(k)
+					assert.Error(err, "Block cid at height %d should be pruned", k)
+				} else {
+					_, err = bstore.LoadBlockCid(k)
+					assert.NoError(err)
 				}
 			}
 		})
@@ -128,3 +194,7 @@ func TestStorePruning(t *testing.T) {
 }
 
 // TODO: prune twice
+
+func randBool() bool {
+	return rand.Intn(2) == 0
+}

--- a/store/store.go
+++ b/store/store.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/dymensionxyz/dymint/types"
 	pb "github.com/dymensionxyz/dymint/types/pb/dymint"
+	"github.com/dymensionxyz/gerr-cosmos/gerrc"
 )
 
 var (
@@ -288,7 +289,7 @@ func (s *DefaultStore) SaveBlockCid(height uint64, cid cid.Cid, batch KVBatch) (
 func (s *DefaultStore) LoadBlockCid(height uint64) (cid.Cid, error) {
 	cidBytes, err := s.db.Get(getCidKey(height))
 	if err != nil {
-		return cid.Undef, fmt.Errorf("load cid for height %v: %w", height, err)
+		return cid.Undef, fmt.Errorf("load cid for height %v: %w", height, gerrc.ErrNotFound)
 	}
 	parsedCid, err := cid.Parse(string(cidBytes))
 	if err != nil {

--- a/store/store.go
+++ b/store/store.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/dymensionxyz/dymint/types"
 	pb "github.com/dymensionxyz/dymint/types/pb/dymint"
-	"github.com/dymensionxyz/gerr-cosmos/gerrc"
 )
 
 var (
@@ -289,7 +288,7 @@ func (s *DefaultStore) SaveBlockCid(height uint64, cid cid.Cid, batch KVBatch) (
 func (s *DefaultStore) LoadBlockCid(height uint64) (cid.Cid, error) {
 	cidBytes, err := s.db.Get(getCidKey(height))
 	if err != nil {
-		return cid.Undef, fmt.Errorf("load cid for height %v: %w", height, gerrc.ErrNotFound)
+		return cid.Undef, fmt.Errorf("load cid for height %v: %w", height, err)
 	}
 	parsedCid, err := cid.Parse(string(cidBytes))
 	if err != nil {

--- a/store/storeIface.go
+++ b/store/storeIface.go
@@ -71,7 +71,7 @@ type Store interface {
 
 	LoadSequencers(height uint64) (*types.SequencerSet, error)
 
-	PruneBlocks(from, to uint64, logger types.Logger) (uint64, error)
+	PruneStore(from, to uint64, logger types.Logger) (uint64, error)
 
 	Close() error
 

--- a/store/storeIface.go
+++ b/store/storeIface.go
@@ -71,7 +71,7 @@ type Store interface {
 
 	LoadSequencers(height uint64) (*types.SequencerSet, error)
 
-	PruneBlocks(from, to uint64) (uint64, error)
+	PruneBlocks(from, to uint64, logger types.Logger) (uint64, error)
 
 	Close() error
 


### PR DESCRIPTION
# PR Standards

## Opening a pull request should be able to meet the following requirements

In case there is some height with a key missing in the store, or in case pruning fails at a specific height for some reason, the pruning returns error.
In this PR this logic is changed and the pruning continues for other heights.
--

PR naming convention: https://hackmd.io/@nZpxHZ0CT7O5ngTp0TP9mg/HJP_jrm7A

---

Close #1039 

<-- Briefly describe the content of this pull request -->

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
