### PR TITLE
fix(validator set): use comet compatible API for validators set wrt hash

### DIFF
--- a/block/initchain.go
+++ b/block/initchain.go
@@ -13,10 +13,7 @@ func (m *Manager) RunInitChain(ctx context.Context) error {
 	if proposer == nil {
 		return errors.New("failed to get proposer")
 	}
-	tmProposer, err := proposer.TMValidator()
-	if err != nil {
-		return err
-	}
+	tmProposer := proposer.TMValidator()
 	res, err := m.Executor.InitChain(m.Genesis, []*tmtypes.Validator{tmProposer})
 	if err != nil {
 		return err

--- a/block/sequencers.go
+++ b/block/sequencers.go
@@ -117,7 +117,7 @@ func (m *Manager) CompleteRotation(ctx context.Context, nextSeqAddr string) erro
 		if seq == nil {
 			return types.ErrMissingProposerPubKey
 		}
-		copy(nextSeqHash[:], seq.Hash())
+		copy(nextSeqHash[:], seq.MustHash())
 	}
 
 	err := m.CreateAndPostLastBatch(ctx, nextSeqHash)

--- a/block/state.go
+++ b/block/state.go
@@ -161,7 +161,7 @@ func (e *Executor) UpdateProposerFromBlock(s *types.State, block *types.Block) b
 	}
 
 	localSeq := s.Sequencers.GetByConsAddress(e.localAddress)
-	if localSeq != nil && bytes.Equal(localSeq.Hash(), block.Header.NextSequencersHash[:]) {
+	if localSeq != nil && bytes.Equal(localSeq.MustHash(), block.Header.NextSequencersHash[:]) {
 		return true
 	}
 

--- a/rpc/client/client.go
+++ b/rpc/client/client.go
@@ -512,31 +512,11 @@ func (c *Client) Validators(ctx context.Context, heightPtr *int64, pagePtr, perP
 	if err != nil {
 		return nil, fmt.Errorf("load validators for height %d: %w", height, err)
 	}
-
-	totalCount := len(sequencers.Sequencers)
-	perPage := validatePerPage(perPagePtr)
-	page, err := validatePage(pagePtr, perPage, totalCount)
-	if err != nil {
-		return nil, err
-	}
-
-	skipCount := validateSkipCount(page, perPage)
-
-	var vals []*tmtypes.Validator
-	for _, s := range sequencers.Sequencers {
-		val, err := s.TMValidator()
-		if err != nil {
-			return nil, fmt.Errorf("convert sequencer to validator: %s :%w", s.SettlementAddress, err)
-		}
-		vals = append(vals, val)
-	}
-
-	v := vals[skipCount : skipCount+tmmath.MinInt(perPage, totalCount-skipCount)]
 	return &ctypes.ResultValidators{
 		BlockHeight: int64(height),
-		Validators:  v,
-		Count:       len(v),
-		Total:       totalCount,
+		Validators:  []*tmtypes.Validator{sequencers.Proposer.TMValidator()},
+		Count:       1,
+		Total:       1,
 	}, nil
 }
 

--- a/rpc/client/client.go
+++ b/rpc/client/client.go
@@ -514,7 +514,7 @@ func (c *Client) Validators(ctx context.Context, heightPtr *int64, pagePtr, perP
 	}
 	return &ctypes.ResultValidators{
 		BlockHeight: int64(height),
-		Validators:  []*tmtypes.Validator{sequencers.Proposer.TMValidator()},
+		Validators:  sequencers.Proposer.TMValidators(),
 		Count:       1,
 		Total:       1,
 	}, nil

--- a/testutil/types.go
+++ b/testutil/types.go
@@ -89,7 +89,7 @@ func generateBlock(height uint64, proposerHash []byte) *types.Block {
 func GenerateBlocksWithTxs(startHeight uint64, num uint64, proposerKey crypto.PrivKey, nTxs int) ([]*types.Block, error) {
 	r, _ := proposerKey.Raw()
 	seq := types.NewSequencerFromValidator(*tmtypes.NewValidator(ed25519.PrivKey(r).PubKey(), 1))
-	proposerHash := seq.Hash()
+	proposerHash := seq.MustHash()
 
 	blocks := make([]*types.Block, num)
 	for i := uint64(0); i < num; i++ {
@@ -122,7 +122,7 @@ func GenerateBlocksWithTxs(startHeight uint64, num uint64, proposerKey crypto.Pr
 func GenerateBlocks(startHeight uint64, num uint64, proposerKey crypto.PrivKey) ([]*types.Block, error) {
 	r, _ := proposerKey.Raw()
 	seq := types.NewSequencerFromValidator(*tmtypes.NewValidator(ed25519.PrivKey(r).PubKey(), 1))
-	proposerHash := seq.Hash()
+	proposerHash := seq.MustHash()
 
 	blocks := make([]*types.Block, num)
 	for i := uint64(0); i < num; i++ {

--- a/types/sequencer_set.go
+++ b/types/sequencer_set.go
@@ -34,8 +34,8 @@ func (s Sequencer) IsEmpty() bool {
 	return s.val.PubKey == nil
 }
 
-func (s Sequencer) TMValidator() (*types.Validator, error) {
-	return &s.val, nil
+func (s Sequencer) TMValidator() *types.Validator {
+	return &s.val
 }
 
 func (s Sequencer) ConsAddress() string {
@@ -62,6 +62,8 @@ type SequencerSet struct {
 	// proposer is also included in the sequencers set
 	Proposer *Sequencer `json:"proposer"`
 }
+
+func (s *SequencerSet) TMProposer()
 
 func (s *SequencerSet) GetProposerPubKey() tmcrypto.PubKey {
 	if s.Proposer == nil {


### PR DESCRIPTION
I guess it should work, I haven't e2e tested it

# PR Standards

## Opening a pull request should be able to meet the following requirements

--

PR naming convention: https://hackmd.io/@nZpxHZ0CT7O5ngTp0TP9mg/HJP_jrm7A

---

Close #https://github.com/dymensionxyz/dymint/issues/1134

<-- Briefly describe the content of this pull request -->

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
