### PR TITLE
fix(validation): set right validation height

### DIFF
--- a/block/validate.go
+++ b/block/validate.go
@@ -30,9 +30,9 @@ func (m *Manager) SettlementValidateLoop(ctx context.Context) error {
 			return ctx.Err()
 		case <-m.settlementValidationC:
 
-			m.logger.Info("validating state updates to target height", "targetHeight", m.LastSettlementHeight.Load())
+			m.logger.Info("validating state updates to target height", "targetHeight", min(m.LastSettlementHeight.Load(), m.State.Height()))
 
-			for currH := m.SettlementValidator.NextValidationHeight(); currH <= m.LastSettlementHeight.Load(); currH = m.SettlementValidator.NextValidationHeight() {
+			for currH := m.SettlementValidator.NextValidationHeight(); currH <= min(m.LastSettlementHeight.Load(), m.State.Height()); currH = m.SettlementValidator.NextValidationHeight() {
 
 				// get next batch that needs to be validated from SL
 				batch, err := m.SLClient.GetBatchAtHeight(currH)


### PR DESCRIPTION
# PR Standards

In the validation loop, it may fail to validate because it tries to validate to heights for blocks that are not applied yet. 
This PR fixes this by never validating heights that are not applied yet. 

## Opening a pull request should be able to meet the following requirements

--

PR naming convention: https://hackmd.io/@nZpxHZ0CT7O5ngTp0TP9mg/HJP_jrm7A

---

Close #1186 

<-- Briefly describe the content of this pull request -->

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
