### PR TITLE
fix(sl): when getting proposer per height get all sequencers and not just bonded

### DIFF
--- a/settlement/dymension/dymension.go
+++ b/settlement/dymension/dymension.go
@@ -314,7 +314,7 @@ func (c *Client) GetLatestFinalizedHeight() (uint64, error) {
 // In case of negative height, it will return the latest proposer.
 func (c *Client) GetProposerAtHeight(height int64) (*types.Sequencer, error) {
 	// Get all sequencers to find the proposer address
-	seqs, err := c.GetBondedSequencers()
+	seqs, err := c.GetAllSequencers()
 	if err != nil {
 		return nil, fmt.Errorf("get bonded sequencers: %w", err)
 	}


### PR DESCRIPTION
# PR Standards

## Opening a pull request should be able to meet the following requirements

--

PR naming convention: https://hackmd.io/@nZpxHZ0CT7O5ngTp0TP9mg/HJP_jrm7A

---

Close #1197 

<-- Briefly describe the content of this pull request -->

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
