### PR TITLE
fix(UT): `TestWebsocketCloseUnsubscribe` race condition fix

### DIFF
--- a/rpc/json/ws_test.go
+++ b/rpc/json/ws_test.go
@@ -144,4 +144,6 @@ func TestWebsocketCloseUnsubscribe(t *testing.T) {
 	assert.Eventually(func() bool {
 		return subscribed_clients == local.EventBus.NumClients()
 	}, 3*time.Second, 100*time.Millisecond)
+
+	srv.Close()
 }


### PR DESCRIPTION
# PR Standards

## Opening a pull request should be able to meet the following requirements

--

PR naming convention: https://hackmd.io/@nZpxHZ0CT7O5ngTp0TP9mg/HJP_jrm7A

---

Close #XXX

<-- Briefly describe the content of this pull request -->

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
