### PR TITLE
fix(block): da unavailability fixes

### DIFF
--- a/block/retriever.go
+++ b/block/retriever.go
@@ -47,6 +47,12 @@ func (m *Manager) ApplyBatchFromSL(slBatch *settlement.Batch) error {
 			m.blockCache.Delete(block.Header.Height)
 		}
 	}
+
+	// if no blocks were applied, we are stuck
+	if lastAppliedHeight == 0 {
+		return fmt.Errorf("no applicable blocks found in the DA")
+	}
+
 	types.LastReceivedDAHeightGauge.Set(lastAppliedHeight)
 
 	return nil

--- a/block/sync.go
+++ b/block/sync.go
@@ -73,12 +73,6 @@ func (m *Manager) SettlementSyncLoop(ctx context.Context) error {
 					return fmt.Errorf("process next DA batch. err:%w", err)
 				}
 
-				// if height havent been updated, we are stuck
-				// this covers the scenario where no applicable blocks were found in the DA
-				if m.State.NextHeight() == currH {
-					return fmt.Errorf("stuck at height %d", currH)
-				}
-
 				m.logger.Info("Synced from DA", "store height", m.State.Height(), "target height", m.LastSettlementHeight.Load())
 
 				// trigger state update validation, after each state update is applied

--- a/block/sync.go
+++ b/block/sync.go
@@ -70,8 +70,7 @@ func (m *Manager) SettlementSyncLoop(ctx context.Context) error {
 
 				err = m.ApplyBatchFromSL(settlementBatch.Batch)
 				if err != nil {
-					m.logger.Error("Apply batch from SL", "err", err)
-					break
+					return fmt.Errorf("process next DA batch. err:%w", err)
 				}
 
 				// if height havent been updated, we are stuck


### PR DESCRIPTION
* if `ApplyBatchFromSL` fails, don't go unhealthy (might be caused due to DA unavailability)
* avoid being stuck in an infinite loop in case of missing DA data