### PR TITLE
chore: added integer overflow linter error to exclude list

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,6 +60,9 @@ issues:
     - mempool
     - state/indexer
     - state/txindex
+  exclude-rules:
+    - text: "G115: integer overflow conversion"
+      linters: [ gosec ]
 
 
 linters-settings:

--- a/block/submit.go
+++ b/block/submit.go
@@ -210,7 +210,7 @@ func (m *Manager) CreateBatch(maxBatchSize uint64, startHeight uint64, endHeight
 		batch.DRSVersion = append(batch.DRSVersion, drsVersion)
 
 		totalSize := batch.SizeBytes()
-		if int(maxBatchSize) < totalSize {
+		if maxBatchSize < uint64(totalSize) {
 
 			// Remove the last block and commit from the batch
 			batch.Blocks = batch.Blocks[:len(batch.Blocks)-1]


### PR DESCRIPTION
# PR Standards

Linter CI is failing with multiple "G115: integer overflow conversion" errors. All these errors are false positives; conversions were done intentionally, and there is no way to fix them (or there are, but hardly feasible). Adding `//nolint:gosec` everywhere is annoying, so I decided to exclude the G115 error from linter. 

For example:
```
2024-11-11T19:31:33.8301723Z ##[error]block/executor.go:317:19: G115: integer overflow conversion int -> uint32 (gosec)
2024-11-11T19:31:33.8311382Z 				Index:  uint32(i),
2024-11-11T19:31:33.8312034Z 				              ^
2024-11-11T19:31:33.8313738Z ##[error]block/fork.go:164:19: G115: integer overflow conversion uint64 -> uint32 (gosec)
2024-11-11T19:31:33.8315742Z 		if drs == uint32(actualDRS) {
2024-11-11T19:31:33.8316405Z 		                ^
2024-11-11T19:31:33.8319188Z ##[error]block/fork.go:172:22: unnecessary conversion (unconvert)
2024-11-11T19:31:33.8320829Z 			DrsVersion: uint64(actualDRS),
2024-11-11T19:31:33.8321488Z 			                  ^
2024-11-11T19:31:33.8322719Z ##[error]block/manager.go:204:43: G115: integer overflow conversion uint64 -> uint32 (gosec)
2024-11-11T19:31:33.8324735Z 			state.RollappParams.DrsVersion = uint32(drsVersion)
2024-11-11T19:31:33.8325861Z 			                                       ^
2024-11-11T19:31:33.8327669Z ##[error]block/manager.go:368:11: G115: integer overflow conversion uint64 -> uint32 (gosec)
2024-11-11T19:31:33.8330098Z 	if uint32(drsVersion) != m.State.RollappParams.DrsVersion {
2024-11-11T19:31:33.8330975Z 	         ^
2024-11-11T19:31:33.8332500Z ##[error]block/submit.go:221:9: G115: integer overflow conversion uint64 -> int (gosec)
2024-11-11T19:31:33.8334403Z 		if int(maxBatchSize) < totalSize {
2024-11-11T19:31:33.8334990Z 		      ^
2024-11-11T19:31:33.8336198Z ##[error]da/celestia/celestia.go:501:24: G115: integer overflow conversion int -> uint32 (gosec)
2024-11-11T19:31:33.8337337Z 		blobSizes[i] = uint32(len(blob.Data))
2024-11-11T19:31:33.8337730Z 		                     ^
2024-11-11T19:31:33.8338708Z ##[error]da/celestia/types/types.go:92:12: G115: integer overflow conversion int -> uint32 (gosec)
2024-11-11T19:31:33.8339866Z 	for uint32(bytesAvailable) < sequenceLen {
2024-11-11T19:31:33.8340239Z 	          ^
2024-11-11T19:31:33.8341207Z ##[error]da/grpc/mockserv/mockserv.go:53:36: G115: integer overflow conversion uint64 -> int32 (gosec)
2024-11-11T19:31:33.8342335Z 			Code:            dalc.StatusCode(resp.Code),
2024-11-11T19:31:33.8342818Z 			                                ^
2024-11-11T19:31:33.8343766Z ##[error]da/grpc/mockserv/mockserv.go:67:28: G115: integer overflow conversion uint64 -> int32 (gosec)
2024-11-11T19:31:33.8344902Z 			Code:    dalc.StatusCode(resp.Code),
2024-11-11T19:31:33.8345725Z 			                        ^
2024-11-11T19:31:33.8346679Z ##[error]da/grpc/mockserv/mockserv.go:84:28: G115: integer overflow conversion uint64 -> int32 (gosec)
2024-11-11T19:31:33.8348001Z 			Code:    dalc.StatusCode(resp.Code),
2024-11-11T19:31:33.8348408Z 			                        ^
2024-11-11T19:31:33.8349390Z ##[error]rpc/client/client.go:314:8: G115: integer overflow conversion uint -> int (gosec)
2024-11-11T19:31:33.8350450Z 	if int(id) > chunkLen-1 {
2024-11-11T19:31:33.8350944Z 	      ^
2024-11-11T19:31:33.8352019Z ##[error]rpc/client/client.go:320:19: G115: integer overflow conversion uint -> int (gosec)
2024-11-11T19:31:33.8353069Z 		ChunkNumber: int(id),
2024-11-11T19:31:33.8353376Z 		                ^
2024-11-11T19:31:33.8354250Z ##[error]types/block.go:49:27: G115: integer overflow conversion uint64 -> int64 (gosec)
2024-11-11T19:31:33.8355260Z 	return time.Unix(0, int64(h.Time))
2024-11-11T19:31:33.8355650Z 	                         ^
2024-11-11T19:31:33.8356487Z ##[error]types/conv.go:26:16: G115: integer overflow conversion uint64 -> int64 (gosec)
2024-11-11T19:31:33.8357517Z 		Height: int64(header.Height),
2024-11-11T19:31:33.8357841Z 		             ^
2024-11-11T19:31:33.8358578Z ##[error]types/conv.go:27:29: G115: integer overflow conversion uint64 -> int64 (gosec)
2024-11-11T19:31:33.8359583Z 		Time:   time.Unix(0, int64(header.Time)),
2024-11-11T19:31:33.8360172Z 		                          ^
2024-11-11T19:31:33.8361691Z ##[error]types/pb/dymensionxyz/dymension/rollapp/message_update_state.go:38:27: G115: integer overflow conversion uint64 -> int (gosec)
2024-11-11T19:31:33.8363296Z 	if len(msg.BDs.BD) != int(msg.NumBlocks) {
2024-11-11T19:31:33.8363726Z 	                         ^
2024-11-11T19:31:33.8363905Z 
2024-11-11T19:31:33.8379505Z ##[error]issues found
2024-11-11T19:31:33.8380459Z Ran golangci-lint in 114348ms
```
[logs_30757136338.zip](https://github.com/user-attachments/files/17714057/logs_30757136338.zip)


---

Close #XXX

<-- Briefly describe the content of this pull request -->

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
