### PR TITLE
feat: produce empty blocks if there are any sequencer set updates

### DIFF
--- a/block/produce.go
+++ b/block/produce.go
@@ -130,8 +130,8 @@ func (m *Manager) produceApplyGossip(ctx context.Context, opts ProduceBlockOptio
 	if err != nil {
 		return nil, nil, fmt.Errorf("snapshot sequencer set: %w", err)
 	}
-	// We want to propagate sequencer set updated to the Rollapp even if the block is empty.
-	// Therefore, we allow empty blocks if there are any sequencer set updates.
+	// We do not want to wait for a new block created to propagate a new sequencer set.
+	// Therefore, we force an empty block if there are any sequencer set updates.
 	opts.AllowEmpty = opts.AllowEmpty || len(newSequencerSet) > 0
 
 	// If I'm not the current rollapp proposer, I should not produce a blocks.


### PR DESCRIPTION
# PR Standards

List of corner cases: https://www.notion.so/dymension/UpsertSequencer-consensus-msg-corner-cases-150a4a51f86a800caaa3fcd8d3a33adb?pvs=4

| Scenario                                                                                                 | Reboot | In-memory set | Store set  | Rollapp state | Produce next empty block                                                                                               |
|----------------------------------------------------------------------------------------------------------|--------|---------------|------------|---------------|------------------------------------------------------------------------------------------------------------------------|
| Fail before SnapshotSequencerSet                                                                         | True   | Height N+1    | Height N   | Height N      | True. There is a diff between memory and store.                                                                        |
| Fail after SnapshotSequencerSet, before block is created  (unrecoverable err; no recoverable in between) | True   | Height N+1    | Height N   | Height N      | True. There is a diff between memory and store.                                                                        |
| Fail after block is created, before block commit  (unrecoverable err; no recoverable in between)         | True   | Height N+1    | Height N   | Height N      | True. There is a diff between memory and store.                                                                        |
| Fail after block commit, before m.Store commit  (unrecoverable err; no recoverable in between)           | True   | Height N+1    | Height N   | Height N+1    | True. There is a diff between memory and store. However, the Rollapp state is updated. Duplicated consensus msgs case. |
| Fail after m.Store commit  (unrecoverable err)                                                           | True   | Height N+1    | Height N+1 | Height N+1    | False. Set is already commited to the rollapp, don't need to intentionally create an empty block.                      |
| Fail after m.Store commit  (recoverable err)                                                             | False  | Height N+1    | Height N+1 | Height N+1    | False. Set is already commited to the rollapp, don't need to intentionally create an empty block.                      |
| Success                                                                                                  | False  | Height N+1    | Height N+1 | Height N+1    | False. Set is already commited to the rollapp.                                                                         |


Close #1262

<-- Briefly describe the content of this pull request -->

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
