### PR TITLE
fix(fork): drs upgrade when multiple forks fix

### DIFF
--- a/block/fork.go
+++ b/block/fork.go
@@ -98,8 +98,8 @@ func shouldStopNode(
 	return nextHeight >= expectedRevision.StartHeight && actualRevisionNumber < expectedRevision.Number
 }
 
-// getRevision returns revision data for the specific height
-func (m *Manager) getRevision(height uint64) (types.Revision, error) {
+// getRevisionFromSL returns revision data for the specific height
+func (m *Manager) getRevisionFromSL(height uint64) (types.Revision, error) {
 	rollapp, err := m.SLClient.GetRollapp()
 	if err != nil {
 		return types.Revision{}, err
@@ -230,7 +230,7 @@ func (m *Manager) updateStateWhenFork() error {
 	// in case fork is detected dymint state needs to be updated
 
 	// get last revision
-	lastRevision, err := m.getRevision(m.State.NextHeight())
+	lastRevision, err := m.getRevisionFromSL(m.State.NextHeight())
 	if err != nil {
 		return err
 	}
@@ -275,7 +275,7 @@ func (m *Manager) checkRevisionAndFork() error {
 	}
 
 	// get revision next height
-	expectedRevision, err := m.getRevision(m.State.NextHeight())
+	expectedRevision, err := m.getRevisionFromSL(m.State.NextHeight())
 	if err != nil {
 		return err
 	}

--- a/block/fork.go
+++ b/block/fork.go
@@ -260,7 +260,6 @@ func (m *Manager) updateStateWhenFork() error {
 
 // checkRevisionAndFork checks if fork is needed after syncing, and performs fork actions
 func (m *Manager) checkRevisionAndFork() error {
-
 	defer m.forkMu.Unlock()
 	m.forkMu.Lock()
 

--- a/block/fork.go
+++ b/block/fork.go
@@ -98,7 +98,7 @@ func shouldStopNode(
 	return nextHeight >= expectedRevision.StartHeight && actualRevisionNumber < expectedRevision.Number
 }
 
-// forkNeeded returns true if fork action is required
+// forkNeeded returns true + fork data if fork action is required
 func (m *Manager) forkNeeded() (types.Instruction, bool) {
 	rollapp, err := m.SLClient.GetRollapp()
 	if err != nil {

--- a/block/fork.go
+++ b/block/fork.go
@@ -111,7 +111,7 @@ func (m *Manager) getRevisionFromSL(height uint64) (types.Revision, error) {
 func (m *Manager) doFork(instruction types.Instruction) error {
 	// if fork (two) blocks are not produced and applied yet, produce them
 	if m.State.Height() < instruction.RevisionStartHeight+1 {
-		// add consensus msgs for upgrade DRS only if current DRS is obsolete
+		// add consensus msgs to upgrade DRS to running node version (msg is created in all cases and RDK will upgrade if necessary). If returns error if running version is deprecated.
 		consensusMsgs, err := m.prepareDRSUpgradeMessages(instruction.FaultyDRS)
 		if err != nil {
 			return fmt.Errorf("prepare DRS upgrade messages: %v", err)

--- a/block/fork.go
+++ b/block/fork.go
@@ -69,7 +69,7 @@ func (m *Manager) checkForkUpdate(msg string) error {
 	return nil
 }
 
-// createInstruction writes file to disk with fork information
+// createInstruction returns instruction with fork information
 func (m *Manager) createInstruction(expectedRevision types.Revision) (types.Instruction, error) {
 	obsoleteDrs, err := m.SLClient.GetObsoleteDrs()
 	if err != nil {

--- a/block/fork_test.go
+++ b/block/fork_test.go
@@ -87,7 +87,7 @@ func TestShouldStopNode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			expectedRevision := tt.rollapp.GetRevisionForHeight(tt.height)
-			result := shouldStopNode(expectedRevision, tt.height, tt.block.Header.Version.App, tt.runMode)
+			result := shouldStopNode(expectedRevision, tt.height, tt.block.Header.Version.App)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/block/manager.go
+++ b/block/manager.go
@@ -78,6 +78,9 @@ type Manager struct {
 
 	// LastBlockTime is the time of last produced block, used to measure batch skew time
 	LastBlockTime atomic.Int64
+
+	// mutex used to avoid stopping node when fork is detected but proposer is creating/sending fork batch
+	forkMu sync.Mutex
 	/*
 		Sequencer and full-node
 	*/
@@ -247,13 +250,9 @@ func (m *Manager) Start(ctx context.Context) error {
 		return fmt.Errorf("am i proposer on SL: %w", err)
 	}
 
-	if amIProposerOnSL || m.AmIProposerOnRollapp() {
-		m.RunMode = RunModeProposer
-	} else {
-		m.RunMode = RunModeFullNode
-	}
+	amIProposer := amIProposerOnSL || m.AmIProposerOnRollapp()
 
-	m.logger.Info("starting block manager", "mode", map[bool]string{true: "proposer", false: "full node"}[m.RunMode == RunModeProposer])
+	m.logger.Info("starting block manager", "mode", map[bool]string{true: "proposer", false: "full node"}[amIProposer])
 
 	// update local state from latest state in settlement
 	err = m.updateFromLastSettlementState()
@@ -292,7 +291,7 @@ func (m *Manager) Start(ctx context.Context) error {
 	})
 
 	// run based on the node role
-	if m.RunMode == RunModeFullNode {
+	if !amIProposer {
 		return m.runAsFullNode(ctx, eg)
 	}
 

--- a/block/manager.go
+++ b/block/manager.go
@@ -196,8 +196,8 @@ func NewManager(
 		return nil, err
 	}
 
-	// update dymint state with fork info
-	err = m.updateStateWhenFork()
+	// update dymint state with next revision info
+	err = m.updateStateForNextRevision()
 	if err != nil {
 		return nil, err
 	}

--- a/block/modes.go
+++ b/block/modes.go
@@ -39,7 +39,6 @@ func (m *Manager) runAsFullNode(ctx context.Context, eg *errgroup.Group) error {
 
 	// remove instruction file after fork to avoid enter fork loop again
 	return types.DeleteInstructionFromDisk(m.RootDir)
-
 }
 
 func (m *Manager) runAsProposer(ctx context.Context, eg *errgroup.Group) error {

--- a/block/modes.go
+++ b/block/modes.go
@@ -65,7 +65,7 @@ func (m *Manager) runAsProposer(ctx context.Context, eg *errgroup.Group) error {
 		return fmt.Errorf("the node is no longer the proposer. please restart.")
 	}
 
-	// update sequencer in case it changed after syncing
+	// update l2 proposer from SL in case it changed after syncing
 	err = m.UpdateProposerFromSL()
 	if err != nil {
 		return err

--- a/block/modes.go
+++ b/block/modes.go
@@ -37,15 +37,9 @@ func (m *Manager) runAsFullNode(ctx context.Context, eg *errgroup.Group) error {
 
 	m.subscribeFullNodeEvents(ctx)
 
-	if _, instructionExists := m.forkNeeded(); instructionExists {
-		// remove instruction file after fork to avoid enter fork loop again
-		err := types.DeleteInstructionFromDisk(m.RootDir)
-		if err != nil {
-			return fmt.Errorf("deleting instruction file: %w", err)
-		}
-	}
+	// remove instruction file after fork to avoid enter fork loop again
+	return types.DeleteInstructionFromDisk(m.RootDir)
 
-	return nil
 }
 
 func (m *Manager) runAsProposer(ctx context.Context, eg *errgroup.Group) error {

--- a/block/modes.go
+++ b/block/modes.go
@@ -23,6 +23,7 @@ const (
 // setFraudHandler sets the fraud handler for the block manager.
 func (m *Manager) runAsFullNode(ctx context.Context, eg *errgroup.Group) error {
 	m.logger.Info("starting block manager", "mode", "full node")
+	m.RunMode = RunModeFullNode
 	// update latest finalized height
 	err := m.updateLastFinalizedHeightFromSettlement()
 	if err != nil {
@@ -49,6 +50,7 @@ func (m *Manager) runAsFullNode(ctx context.Context, eg *errgroup.Group) error {
 
 func (m *Manager) runAsProposer(ctx context.Context, eg *errgroup.Group) error {
 	m.logger.Info("starting block manager", "mode", "proposer")
+	m.RunMode = RunModeProposer
 	// Subscribe to batch events, to update last submitted height in case batch confirmation was lost. This could happen if the sequencer crash/restarted just after submitting a batch to the settlement and by the time we query the last batch, this batch wasn't accepted yet.
 	go uevent.MustSubscribe(ctx, m.Pubsub, "updateSubmittedHeightLoop", settlement.EventQueryNewSettlementBatchAccepted, m.UpdateLastSubmittedHeight, m.logger)
 	// Subscribe to P2P received blocks events (used for P2P syncing).

--- a/block/production_test.go
+++ b/block/production_test.go
@@ -329,6 +329,7 @@ func TestUpdateInitialSequencerSet(t *testing.T) {
 	slmock.On("Start").Return(nil)
 	slmock.On("GetProposer").Return(proposer)
 	slmock.On("GetAllSequencers").Return([]types.Sequencer{proposer, sequencer}, nil)
+	slmock.On("GetRollapp").Return(&types.Rollapp{}, nil)
 
 	manager, err := testutil.GetManagerWithProposerKey(testutil.GetManagerConfig(), lib2pPrivKey, slmock, 1, 1, 0, proxyApp, nil)
 	require.NoError(err)
@@ -459,6 +460,7 @@ func TestUpdateExistingSequencerSet(t *testing.T) {
 	slmock.On("Init", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	slmock.On("Start").Return(nil)
 	slmock.On("GetProposer").Return(proposer)
+	slmock.On("GetRollapp").Return(&types.Rollapp{}, nil)
 
 	manager, err := testutil.GetManagerWithProposerKey(testutil.GetManagerConfig(), lib2pPrivKey, slmock, 1, 1, 0, proxyApp, nil)
 	require.NoError(err)

--- a/block/submit_test.go
+++ b/block/submit_test.go
@@ -193,6 +193,7 @@ func TestBatchSubmissionFailedSubmission(t *testing.T) {
 	slmock.On("Init", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	slmock.On("Start").Return(nil)
 	slmock.On("GetProposer").Return(proposer)
+	slmock.On("GetRollapp").Return(&types.Rollapp{}, nil)
 
 	manager, err := testutil.GetManagerWithProposerKey(testutil.GetManagerConfig(), lib2pPrivKey, slmock, 1, 1, 0, proxyApp, nil)
 	require.NoError(err)

--- a/types/instruction.go
+++ b/types/instruction.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -52,11 +53,12 @@ func InstructionExists(dir string) bool {
 }
 
 func DeleteInstructionFromDisk(dir string) error {
-	filePath := filepath.Join(dir, instructionFileName)
-	err := os.Remove(filePath)
-	if err != nil {
-		return err
+	if !InstructionExists(dir) {
+		return nil
 	}
-
+	filePath := filepath.Join(dir, instructionFileName)
+	if err := os.Remove(filePath); err != nil {
+		return fmt.Errorf("deleting instruction file: %w", err)
+	}
 	return nil
 }


### PR DESCRIPTION
# PR Standards
The objective of this PR is to fix detected issues in forking process:
* Stop condition modified to avoid stopping active proposers when submitting fork batch is wrong, rolled back to previous and added mutex.
* fork for deprecated drs for rollapps with multiple forks did not work because instruction file could have info from wrong fork (for previous height and not next height). its been fixed by getting always fork data from hub using current height.     

## Opening a pull request should be able to meet the following requirements

--

PR naming convention: https://hackmd.io/@nZpxHZ0CT7O5ngTp0TP9mg/HJP_jrm7A

---

Close #1268, #1267 

<-- Briefly describe the content of this pull request -->

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
