### PR TITLE
sequencers_test.go

### DIFF
--- a/block/sequencers_test.go
+++ b/block/sequencers_test.go
@@ -109,7 +109,7 @@ func TestHandleSequencerSetUpdate(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Create a manger
+			// Create a manager
 			manager, err := testutil.GetManager(testutil.GetManagerConfig(), nil, 1, 1, 0, nil, nil)
 			require.NoError(t, err)
 			require.NotNil(t, manager)


### PR DESCRIPTION
## Pull Request Title: Typo Fix in `sequencers_test.go`

### Description:
This pull request fixes a typo in the `sequencers_test.go` file. The word **"manger"** has been corrected to **"manager"**.

### Changes:
- Corrected the typo **"manger"** to **"manager"** in the `TestHandleSequencerSetUpdate` test function.

### Why this change is necessary:
- The typo could lead to confusion and affect the readability of the test code.
- Correcting this typo helps maintain consistency and clarity in the codebase.

### How to test:
- Review the `sequencers_test.go` file to confirm the typo has been fixed.
- Run the test suite to ensure the test still works correctly after the change.

### Additional Information:
- This is a minor correction and does not affect any functionality of the codebase.
