### PR TITLE
fix typo ws_test.go

### DIFF
--- a/rpc/json/ws_test.go
+++ b/rpc/json/ws_test.go
@@ -133,7 +133,7 @@ func TestWebsocketCloseUnsubscribe(t *testing.T) {
 }
 `))
 	assert.NoError(err)
-	// Vaildate we have a new client
+	// Validate we have a new client
 	assert.Eventually(func() bool {
 		return subscribed_clients+1 == local.EventBus.NumClients()
 	}, 3*time.Second, 100*time.Millisecond)


### PR DESCRIPTION
# **Fix Typo in `ws_test.go`**

## **Description**
This pull request corrects a typo in the `ws_test.go` file. The word **"Vaildate"** has been fixed to **"Validate"** to ensure accuracy in the comment.

## **Changes**
- Corrected the typo in the comment:
  - **Before:** `// Vaildate we have a new client`
  - **After:** `// Validate we have a new client`

## **Impact**
- This is a non-functional change that only affects comments, improving the clarity of the code.

## **Testing**
- No testing is required since this is only a comment fix.
