### PR TITLE
refactor: use t.TempDir() instead of os.MkdirTemp

### DIFF
--- a/indexers/txindex/kv/kv_bench_test.go
+++ b/indexers/txindex/kv/kv_bench_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"os"
 	"testing"
 
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -15,15 +14,9 @@ import (
 )
 
 func BenchmarkTxSearch(b *testing.B) {
-	dbDir, err := os.MkdirTemp("", "benchmark_tx_search_test")
-	if err != nil {
-		b.Errorf("create temporary directory: %s", err)
-	}
+	dbDir := b.TempDir()
 
 	db := store.NewDefaultKVStore(dbDir, "db", "benchmark_tx_search_test")
-	if err != nil {
-		b.Errorf("create database: %s", err)
-	}
 
 	indexer := NewTxIndex(db)
 

--- a/indexers/txindex/kv/kv_test.go
+++ b/indexers/txindex/kv/kv_test.go
@@ -3,7 +3,6 @@ package kv
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
@@ -418,15 +417,9 @@ func randomTxHash() string {
 }
 
 func benchmarkTxIndex(txsCount int64, b *testing.B) {
-	dir, err := os.MkdirTemp("", "tx_index_db")
-	require.NoError(b, err)
-	defer func() {
-		err := os.RemoveAll(dir)
-		require.NoError(b, err)
-	}()
+	dir := b.TempDir()
 
 	store := store.NewDefaultKVStore(dir, "db", "tx_index")
-	require.NoError(b, err)
 	indexer := NewTxIndex(store)
 
 	batch := txindex.NewBatch(txsCount, int64(0))
@@ -451,7 +444,7 @@ func benchmarkTxIndex(txsCount int64, b *testing.B) {
 	}
 
 	b.ResetTimer()
-
+	var err error
 	for n := 0; n < b.N; n++ {
 		err = indexer.AddBatch(batch)
 	}

--- a/settlement/local/local_test.go
+++ b/settlement/local/local_test.go
@@ -2,7 +2,6 @@ package local_test
 
 import (
 	"encoding/hex"
-	"os"
 	"testing"
 
 	"github.com/dymensionxyz/dymint/da"
@@ -122,9 +121,7 @@ func TestPersistency(t *testing.T) {
 	require.NoError(err)
 
 	sllayer := local.Client{}
-	tmpdir, err := os.MkdirTemp("/tmp", "")
-	defer os.RemoveAll(tmpdir) // Clean up after the test
-	require.NoError(err)
+	tmpdir := t.TempDir()
 
 	cfg := settlement.Config{KeyringHomeDir: tmpdir, ProposerPubKey: hex.EncodeToString(pubKeybytes)}
 	err = sllayer.Init(cfg, "rollappTest", pubsubServer, logger)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -1,7 +1,6 @@
 package store_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/dymensionxyz/gerr-cosmos/gerrc"
@@ -38,14 +37,7 @@ func TestStoreLoad(t *testing.T) {
 		//}},
 	}
 
-	tmpDir, err := os.MkdirTemp("", "optimint_test")
-	require.NoError(t, err)
-	defer func() {
-		err := os.RemoveAll(tmpDir)
-		if err != nil {
-			t.Log("failed to remove temporary directory", err)
-		}
-	}()
+	tmpDir := t.TempDir()
 
 	for _, kv := range []store.KV{store.NewDefaultInMemoryKVStore(), store.NewDefaultKVStore(tmpDir, "db", "test")} {
 		for _, c := range cases {


### PR DESCRIPTION
# PR Standards

## Opening a pull request should be able to meet the following requirements

--

PR naming convention: https://hackmd.io/@nZpxHZ0CT7O5ngTp0TP9mg/HJP_jrm7A

---

Close #XXX

`TempDir()` is a method introduced in Go 1.15 for `testing.T`. It automatically creates a temporary directory and cleans it up after the test is complete, eliminating the hassle of manually handling errors and cleanup.  More detail about TempDir  https://pkg.go.dev/testing#B.TempDir


<-- Briefly describe the content of this pull request -->

For Author:

- [x]  Targeted PR against correct branch
- [x]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
