### PR TITLE
fix(validation): remove unrecoverable when state info not found 

### DIFF
--- a/config/defaults.go
+++ b/config/defaults.go
@@ -72,7 +72,7 @@ func DefaultConfig(home string) *NodeConfig {
 		DymAccountName:          "sequencer",
 		GasPrices:               "1000000000adym",
 		SLGrpc:                  defaultSlGrpcConfig,
-		RetryMinDelay:           1 * time.Second,
+		RetryMinDelay:           5 * time.Second,
 		RetryMaxDelay:           10 * time.Second,
 		BatchAcceptanceTimeout:  120 * time.Second,
 		BatchAcceptanceAttempts: 5,

--- a/settlement/dymension/dymension.go
+++ b/settlement/dymension/dymension.go
@@ -229,10 +229,6 @@ func (c *Client) getStateInfo(index, height *uint64) (res *rollapptypes.QueryGet
 	}
 	err = c.RunWithRetry(func() error {
 		res, err = c.rollappQueryClient.StateInfo(c.ctx, req)
-
-		if status.Code(err) == codes.NotFound {
-			return retry.Unrecoverable(errors.Join(gerrc.ErrNotFound, err))
-		}
 		return err
 	})
 	if err != nil {


### PR DESCRIPTION
# PR Standards

this pr removes the skip retry because unrecoverable when state info not found, because it could happen if hub node is behind load balancer and are not perfectly synced. with the change it will retry using default values to avoid freezing when small syncing issues on the hub.

## Opening a pull request should be able to meet the following requirements

--

PR naming convention: https://hackmd.io/@nZpxHZ0CT7O5ngTp0TP9mg/HJP_jrm7A

---

Close #XXX

<-- Briefly describe the content of this pull request -->

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
