### PR TITLE
Fix typo in gossip block logging message

### DIFF
--- a/block/p2p.go
+++ b/block/p2p.go
@@ -78,7 +78,7 @@ func (m *Manager) OnReceivedBlock(event pubsub.Message) {
 
 // gossipBlock sends created blocks by the sequencer to full-nodes using P2P gossipSub
 func (m *Manager) gossipBlock(ctx context.Context, block types.Block, commit types.Commit) error {
-	m.logger.Info("Gossipping block", "height", block.Header.Height)
+	m.logger.Info("Gossiping block", "height", block.Header.Height)
 	gossipedBlock := p2p.BlockData{Block: block, Commit: commit}
 	gossipedBlockBytes, err := gossipedBlock.MarshalBinary()
 	if err != nil {
@@ -102,7 +102,7 @@ func (m *Manager) saveP2PBlockToBlockSync(block *types.Block, commit *types.Comm
 	}
 	err = m.P2PClient.SaveBlock(context.Background(), block.Header.Height, block.GetRevision(), gossipedBlockBytes)
 	if err != nil {
-		m.logger.Error("Adding  block to blocksync store.", "err", err, "height", gossipedBlock.Block.Header.Height)
+		m.logger.Error("Adding block to blocksync store.", "err", err, "height", gossipedBlock.Block.Header.Height)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR fixes a spelling error in the p2p.go file by correcting "Gossipping" to "Gossiping" in the log message. This change maintains consistent spelling throughout the codebase.

Changes made:
- Changed logger.Info("Gossipping block"...) to logger.Info("Gossiping block"...).
