### PR TITLE
CI: migrate workflows to checkout v5

### DIFF
--- a/.github/workflows/build_and_push_image.yml
+++ b/.github/workflows/build_and_push_image.yml
@@ -19,7 +19,7 @@ jobs:
       steps:
         - 
           name: Check out the repo
-          uses: actions/checkout@v3
+          uses: actions/checkout@v5
         - 
           name: Set up Docker Buildx
           uses: docker/setup-buildx-action@v3

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/golangci_lint.yml
+++ b/.github/workflows/golangci_lint.yml
@@ -12,7 +12,7 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version: "1.22"

--- a/.github/workflows/label-internal-pr.yml
+++ b/.github/workflows/label-internal-pr.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Get Pull Request Author and Check Membership
         id: pr

--- a/.github/workflows/markdown_lint.yml
+++ b/.github/workflows/markdown_lint.yml
@@ -11,7 +11,7 @@ jobs:
   markdownlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: markdownlint-cli
         uses: nosborn/github-action-markdown-cli@v3.2.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       GOPRIVATE: "github.com/dymensionxyz/*"
       GH_ACCESS_TOKEN: "${{ secrets.GH_ACCESS_TOKEN }}"
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Go
       uses: actions/setup-go@v4


### PR DESCRIPTION
Node 24 compatibility: switch all jobs to actions/checkout@v5. Requires runner v2.327.1+. Pure maintenance, behavior unchanged.

Ref: https://github.com/actions/checkout/releases/tag/v5.0.0