### PR TITLE
chore: fix wrong function name in comment

### DIFF
--- a/p2p/client.go
+++ b/p2p/client.go
@@ -544,7 +544,7 @@ func (c *Client) blockSyncReceived(block *BlockData) {
 	c.blocksReceived.AddBlockReceived(block.Block.Header.Height)
 }
 
-// blockSyncReceived is called on reception of new block via gossip protocol
+// blockGossipReceived is called on reception of new block via gossip protocol
 func (c *Client) blockGossipReceived(ctx context.Context, block []byte) {
 	var gossipedBlock BlockData
 	if err := gossipedBlock.UnmarshalBinary(block); err != nil {

--- a/rpc/json/handler.go
+++ b/rpc/json/handler.go
@@ -55,7 +55,7 @@ func (h *handler) serveJSONRPC(w http.ResponseWriter, r *http.Request) {
 	h.serveJSONRPCforWS(w, r, nil)
 }
 
-// serveJSONRPC serves HTTP request
+// serveJSONRPCforWS serves HTTP request
 // implementation is highly inspired by Gorilla RPC v2 (but simplified a lot)
 func (h *handler) serveJSONRPCforWS(w http.ResponseWriter, r *http.Request, wsConn *wsConn) {
 	// Create a new codec request.

--- a/store/pruning.go
+++ b/store/pruning.go
@@ -29,7 +29,7 @@ func (s *DefaultStore) PruneStore(to uint64, logger types.Logger) (uint64, error
 	return pruned, nil
 }
 
-// pruneHeights prunes all store entries that are stored along blocks (blocks,commit,proposer, etc)
+// PruneHeights prunes all store entries that are stored along blocks (blocks,commit,proposer, etc)
 func (s *DefaultStore) PruneHeights(from, to uint64, logger types.Logger) (uint64, error) {
 	pruneBlocks := func(batch KVBatch, height uint64) error {
 		hash, err := s.loadHashFromIndex(height)


### PR DESCRIPTION
# PR Standards

## Opening a pull request should be able to meet the following requirements

fix wrong function name in comment

---

Close #XXX

<-- Briefly describe the content of this pull request -->

For Author:

- [x]  Targeted PR against correct branch
- [x]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [x]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
